### PR TITLE
Ignore very fresh points from Datadog (fix #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ the `env_variables` section of `app/app.yaml`.
     parallel. Parallel updates are scheduled using goroutines and still happen
     in the context of a single incoming HTTP request, and setting this value too
     high might result in the App Engine instance running out of RAM.
+*   `DATADOG_MIN_POINT_AGE`: minimum age of a data point returned by Datadog
+    that makes it eligible for being written. Points that are very fresh
+    (default is 1 minute) are ignored, since Datadog might return incomplete
+    data for them if some input data is delayed.
 *   `ENABLE_STATUS_PAGE`: can be set to 'yes' to enable the status web page
     (disabled by default).
 

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -16,6 +16,9 @@ env_variables:
   SD_PROJECT_FOR_INTERNAL_METRICS: ""
   # Number of metrics to update in parallel. Must be between 1 and 100 (chosen arbitrarily).
   UPDATE_PARALLELISM: 1
+  # Points received from Datadog that are too fresh will be discarded to allow data to be fully processed and aggregated
+  # on Datadog side. This variable defines the threshold for "too fresh".
+  DATADOG_MIN_POINT_AGE: "1m"
   # Uncomment to enable the status web page.
   #ENABLE_STATUS_PAGE: "yes"
 

--- a/app/main.go
+++ b/app/main.go
@@ -57,7 +57,7 @@ func sync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	config, err := tsbridge.NewConfig(ctx, os.Getenv("CONFIG_FILE"))
+	config, err := newConfig(ctx)
 	if err != nil {
 		logAndReturnError(ctx, w, err)
 		return
@@ -103,7 +103,7 @@ func cleanup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	config, err := tsbridge.NewConfig(ctx, os.Getenv("CONFIG_FILE"))
+	config, err := newConfig(ctx)
 	if err != nil {
 		logAndReturnError(ctx, w, err)
 		return
@@ -122,7 +122,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := appengine.NewContext(r)
-	config, err := tsbridge.NewConfig(ctx, os.Getenv("CONFIG_FILE"))
+	config, err := newConfig(ctx)
 	if err != nil {
 		logAndReturnError(ctx, w, err)
 		return
@@ -137,6 +137,16 @@ func index(w http.ResponseWriter, r *http.Request) {
 	if err := t.Execute(w, config.Metrics()); err != nil {
 		logAndReturnError(ctx, w, err)
 	}
+}
+
+// newConfig initializes and returns tsbridge config.
+func newConfig(ctx context.Context) (*tsbridge.Config, error) {
+	ddMinPointAge, err := time.ParseDuration(os.Getenv("DATADOG_MIN_POINT_AGE"))
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse DATADOG_MIN_POINT_AGE: %v", err)
+	}
+
+	return tsbridge.NewConfig(ctx, os.Getenv("CONFIG_FILE"), ddMinPointAge)
 }
 
 // Since some URLs are triggered by App Engine cron, error messages returned in HTTP response

--- a/tsbridge/config.go
+++ b/tsbridge/config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"github.com/google/ts-bridge/datadog"
 
@@ -67,7 +68,7 @@ func (c *Config) Metrics() []*Metric {
 }
 
 // NewConfig reads and validates a configuration file, returning the Config struct.
-func NewConfig(ctx context.Context, filename string) (*Config, error) {
+func NewConfig(ctx context.Context, filename string, ddMinPointAge time.Duration) (*Config, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -101,7 +102,7 @@ func NewConfig(ctx context.Context, filename string) (*Config, error) {
 		if !ok {
 			return nil, fmt.Errorf("destination '%s' not found", m.Destination)
 		}
-		source := datadog.NewSourceMetric(m.Name, &m.MetricConfig)
+		source := datadog.NewSourceMetric(m.Name, &m.MetricConfig, ddMinPointAge)
 		metric, err := NewMetric(ctx, m.Name, source, project)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create metric '%s': %v", m.Name, err)

--- a/tsbridge/config_test.go
+++ b/tsbridge/config_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/appengine"
 )
@@ -30,7 +31,7 @@ func fakeAppIDFunc(app string) func(context.Context) string {
 }
 
 func TestNewConfigSimple(t *testing.T) {
-	cfg, err := NewConfig(testCtx, "testdata/valid.yaml")
+	cfg, err := NewConfig(testCtx, "testdata/valid.yaml", time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -47,7 +48,7 @@ func TestNewConfigSimple(t *testing.T) {
 	// project_id parameter is required when app id cannot be detected.
 	for _, appid := range []string{"", "None"} {
 		appIDFunc = fakeAppIDFunc(appid)
-		_, err := NewConfig(testCtx, "testdata/valid.yaml")
+		_, err := NewConfig(testCtx, "testdata/valid.yaml", time.Second)
 		if !strings.Contains(err.Error(), "please provide project_id for") {
 			t.Errorf("passing project_id should be required")
 		}
@@ -68,7 +69,7 @@ func TestNewConfigFailedValidation(t *testing.T) {
 		{"no_datadog_keys.yaml", "configuration file validation error"},
 		{"invalid_name.yaml", "configuration file validation error"},
 	} {
-		_, err := NewConfig(testCtx, filepath.Join("testdata", tt.filename))
+		_, err := NewConfig(testCtx, filepath.Join("testdata", tt.filename), time.Second)
 		if !strings.Contains(err.Error(), tt.wantErr) {
 			t.Errorf("expected NewConfig error '%v'; got '%v'", tt.wantErr, err)
 		}


### PR DESCRIPTION
Points that are very fresh (<1m by default) will be ignored, since they
might represent incomplete data.

Issue #8 has slightly more details.