### PR TITLE
Move metric records into a separate module

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/ts-bridge/record"
 	"github.com/google/ts-bridge/stackdriver"
 	"github.com/google/ts-bridge/tsbridge"
 
@@ -109,7 +110,11 @@ func cleanup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := tsbridge.CleanupRecords(ctx, config.Metrics()); err != nil {
+	var metricNames []string
+	for _, m := range config.Metrics() {
+		metricNames = append(metricNames, m.Name)
+	}
+	if err := record.CleanupRecords(ctx, metricNames); err != nil {
 		logAndReturnError(ctx, w, err)
 	}
 }

--- a/datadog/metric.go
+++ b/datadog/metric.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/ts-bridge/record"
+
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	ddapi "github.com/zorkian/go-datadog-api"
@@ -67,7 +69,7 @@ func (m *Metric) Query() string {
 
 // StackdriverData issues a Datadog query, returning metric descriptor and time series data.
 // Time series data will include points since the given timestamp.
-func (m *Metric) StackdriverData(ctx context.Context, since time.Time) (*metricpb.MetricDescriptor, []*monitoringpb.TimeSeries, error) {
+func (m *Metric) StackdriverData(ctx context.Context, since time.Time, record *record.MetricRecord) (*metricpb.MetricDescriptor, []*monitoringpb.TimeSeries, error) {
 	m.client.HttpClient = urlfetch.Client(ctx)
 	// Datadog's `from` parameter is inclusive, so we set it to 1 second after the latest point we've got.
 	series, err := m.client.QueryMetrics(since.Unix()+1, time.Now().Unix(), m.config.Query)

--- a/mocks/mock_source_metric.go
+++ b/mocks/mock_source_metric.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
+	record "github.com/google/ts-bridge/record"
 	metric "google.golang.org/genproto/googleapis/api/metric"
 	v3 "google.golang.org/genproto/googleapis/monitoring/v3"
 	reflect "reflect"
@@ -49,8 +50,8 @@ func (mr *MockSourceMetricMockRecorder) Query() *gomock.Call {
 }
 
 // StackdriverData mocks base method
-func (m *MockSourceMetric) StackdriverData(arg0 context.Context, arg1 time.Time) (*metric.MetricDescriptor, []*v3.TimeSeries, error) {
-	ret := m.ctrl.Call(m, "StackdriverData", arg0, arg1)
+func (m *MockSourceMetric) StackdriverData(arg0 context.Context, arg1 time.Time, arg2 *record.MetricRecord) (*metric.MetricDescriptor, []*v3.TimeSeries, error) {
+	ret := m.ctrl.Call(m, "StackdriverData", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*metric.MetricDescriptor)
 	ret1, _ := ret[1].([]*v3.TimeSeries)
 	ret2, _ := ret[2].(error)
@@ -58,8 +59,8 @@ func (m *MockSourceMetric) StackdriverData(arg0 context.Context, arg1 time.Time)
 }
 
 // StackdriverData indicates an expected call of StackdriverData
-func (mr *MockSourceMetricMockRecorder) StackdriverData(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackdriverData", reflect.TypeOf((*MockSourceMetric)(nil).StackdriverData), arg0, arg1)
+func (mr *MockSourceMetricMockRecorder) StackdriverData(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackdriverData", reflect.TypeOf((*MockSourceMetric)(nil).StackdriverData), arg0, arg1, arg2)
 }
 
 // StackdriverName mocks base method


### PR DESCRIPTION
Also, expose metric records to Datadog code to allow tracking internal counter state for #13.