### PR TITLE
Pin an older version of Google Cloud SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 env:
   - DEP_VERSION="0.5.4" CLOUDSDK_CORE_DISABLE_PROMPTS=1
 install:
-  - curl https://sdk.cloud.google.com | bash
+  - curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-257.0.0-linux-x86_64.tar.gz | tar xfz - -C $HOME
   - $HOME/google-cloud-sdk/bin/gcloud components install app-engine-python app-engine-go cloud-datastore-emulator
   - go get github.com/golang/mock/mockgen
   - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep


### PR DESCRIPTION
It seems that `aetest` is broken in the latest version: https://travis-ci.org/google/ts-bridge/builds/593140628