### PR TITLE
Update documentation with InfluxDB metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Time Series Bridge is a tool that can be used to import metrics from one
 monitoring system into another. It regularly runs a specific query against a
-source monitoring system (currently only Datadog & InfluxDB) and writes
+source monitoring system (currently Datadog & InfluxDB) and writes
 new time series results into the destination system (currently only
 Stackdriver).
 
@@ -86,49 +86,49 @@ using a git repository and
       - name: stackdriver
         project_id: "your_project_name"
     ```
-2.  Turn on the status page (uncomment #ENABLE\_STATUS\_PAGE: "yes" in `app.yaml`)
-3.  Update `SD_PROJECT_FOR_INTERNAL_METRICS` in your `app.yaml` to match the name of your GCP project.
-4.  Launch a dev server
+1.  Turn on the status page (uncomment #ENABLE\_STATUS\_PAGE: "yes" in `app.yaml`)
+1.  Update `SD_PROJECT_FOR_INTERNAL_METRICS` in your `app.yaml` to match the name of your GCP project.
+1.  Launch a dev server
     *   `dev_appserver.py app.yaml --port 18080`
-5.  Test via localhost/sync
+1.  Test via localhost/sync
     *   `curl http://localhost:18080/sync`
-6.  Verify that no error messages are shown. Troubleshooting guide:
+1.  Verify that no error messages are shown. Troubleshooting guide:
 
     | Error message | Remedy |
     | --- | --- |
     | ERROR: StatsCollector: rpc error: code = PermissionDenied desc = The caller does not have permission | Ensure the authenticating user has at least the "Monitoring Editor" role |
 
-7.  Configure metrics by following the instructions
+1.  Configure metrics by following the instructions
     [below](#metrics-yaml-configuration).
-8.  Test metric ingestion via localhost/sync
+1.  Test metric ingestion via localhost/sync
     *   `curl http://localhost:18080/sync`
-9.  Verify that metrics are visible on status page
+1.  Verify that metrics are visible on status page
     *   In Cloud Shell, click the ‘web preview’ button and change the port to
         18080
     *   If running on a local workstation, browse to http://localhost:18080/
-10. Verify that metrics are visible in the
+1.  Verify that metrics are visible in the
     [Stackdriver UI](https://app.google.stackdriver.com/metrics-explorer)
-11. Kill the local dev server
-12. Revert `SD_PROJECT_FOR_INTERNAL_METRICS` to `""` in `app.yaml`
+1.  Kill the local dev server
+1.  Revert `SD_PROJECT_FOR_INTERNAL_METRICS` to `""` in `app.yaml`
 
 ## Deploy In Production
 
 1.  Ensure that you either have **Owner** permissions for the whole Cloud
     project, or at minimum the **App Engine Admin** and **Cloud Scheduler
     Admin** roles
-2.  Disable the status page (comment out ENABLE\_STATUS\_PAGE: "yes" in
+1.  Disable the status page (comment out ENABLE\_STATUS\_PAGE: "yes" in
     `app.yaml`)
     *   See [below](#status-page) if you'd like to keep the status page enabled
         in prod.
-3.  Create the App Engine application
+1.  Create the App Engine application
     *   `gcloud app create`
     *   Choose the App Engine region. If you are using ts-bridge to import
         metrics originating from a system running on GCP, you should run
         ts-bridge in a different Cloud region from the system itself to ensure
         independent failure domains.
-4.  Deploy app
+1.  Deploy app
     *   `gcloud app deploy --project <your_project_name> --version live`
-5.  Verify in the Stackdriver metrics explorer that metrics are being imported
+1.  Verify in the Stackdriver metrics explorer that metrics are being imported
     once a minute
 
 # metrics.yaml Configuration
@@ -206,15 +206,9 @@ the `env_variables` section of `app/app.yaml`.
     incomplete data for them if some input data is delayed.
 *   `COUNTER_RESET_INTERVAL`: while importing counters, ts-bridge needs
     to reset 'start time' regularly to keep the query time window small enough.
-<<<<<<< HEAD
     This parameter defines how often a new start time is chosen, and defaults
     to 30 minutes. See [Cumulative metrics](#cumulative-metrics) section below
     for more details.
-=======
-    This parameter defines how often a new start time is chosen, and is
-    defaulted to 30 minutes. See [Cumulative metrics](#cumulative-metrics)
-    section below for more details.
->>>>>>> Update documentation with InfluxDB
 *   `ENABLE_STATUS_PAGE`: can be set to 'yes' to enable the status web page
     (disabled by default).
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,15 @@ the `env_variables` section of `app/app.yaml`.
     incomplete data for them if some input data is delayed.
 *   `COUNTER_RESET_INTERVAL`: while importing counters, ts-bridge needs
     to reset 'start time' regularly to keep the query time window small enough.
+<<<<<<< HEAD
     This parameter defines how often a new start time is chosen, and defaults
     to 30 minutes. See [Cumulative metrics](#cumulative-metrics) section below
     for more details.
+=======
+    This parameter defines how often a new start time is chosen, and is
+    defaulted to 30 minutes. See [Cumulative metrics](#cumulative-metrics)
+    section below for more details.
+>>>>>>> Update documentation with InfluxDB
 *   `ENABLE_STATUS_PAGE`: can be set to 'yes' to enable the status web page
     (disabled by default).
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ the `env_variables` section of `app/app.yaml`.
     incomplete data for them if some input data is delayed.
 *   `COUNTER_RESET_INTERVAL`: while importing counters, ts-bridge needs
     to reset 'start time' regularly to keep the query time window small enough.
-    This parameter defines how often a new start time is chosen, and is
-    defaulted to 30 minutes. See [Cumulative metrics](#cumulative-metrics)
-    section below for more details.
+    This parameter defines how often a new start time is chosen, and defaults
+    to 30 minutes. See [Cumulative metrics](#cumulative-metrics) section below
+    for more details.
 *   `ENABLE_STATUS_PAGE`: can be set to 'yes' to enable the status web page
     (disabled by default).
 

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -15,7 +15,7 @@ env_variables:
   SD_PROJECT_FOR_INTERNAL_METRICS: ""
   # Number of metrics to update in parallel. Must be between 1 and 100 (chosen arbitrarily).
   UPDATE_PARALLELISM: 1
-  # Points received from metric sources that are too fresh will be discarded to allow data to be fully processed.
+  # Points received from metric sources that are too fresh will be discarded to allow data to settle before being imported.
   # This variable defines the threshold for "too fresh".
   MIN_POINT_AGE: "2m"
   # While importing counters, ts-bridge needs to reset 'start time' regularly to keep the query time window small enough

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -15,13 +15,13 @@ env_variables:
   SD_PROJECT_FOR_INTERNAL_METRICS: ""
   # Number of metrics to update in parallel. Must be between 1 and 100 (chosen arbitrarily).
   UPDATE_PARALLELISM: 1
-  # Points received from Datadog that are too fresh will be discarded to allow data to be fully processed and aggregated
-  # on Datadog side. This variable defines the threshold for "too fresh".
-  DATADOG_MIN_POINT_AGE: "2m"
+  # Points received from metric sources that are too fresh will be discarded to allow data to be fully processed.
+  # This variable defines the threshold for "too fresh".
+  MIN_POINT_AGE: "2m"
   # While importing counters, ts-bridge needs to reset 'start time' regularly to keep the query time window small enough
   # to avoid aggregation. This parameter defines how often a new start time is chosen. 30min should be sufficient for
   # metrics that have a point every 10 seconds.
-  DATADOG_COUNTER_RESET_INTERVAL: "30m"
+  COUNTER_RESET_INTERVAL: "30m"
   # Uncomment to enable the status web page.
   #ENABLE_STATUS_PAGE: "yes"
 

--- a/app/main.go
+++ b/app/main.go
@@ -146,16 +146,14 @@ func index(w http.ResponseWriter, r *http.Request) {
 
 // newConfig initializes and returns tsbridge config.
 func newConfig(ctx context.Context) (*tsbridge.Config, error) {
-	// TODO: update the variable names to make them not unique to Datadog.
-	// This would require documentation update as well for README.md.
-	minPointAge, err := time.ParseDuration(os.Getenv("DATADOG_MIN_POINT_AGE"))
+	minPointAge, err := time.ParseDuration(os.Getenv("MIN_POINT_AGE"))
 	if err != nil {
-		return nil, fmt.Errorf("Could not parse DATADOG_MIN_POINT_AGE: %v", err)
+		return nil, fmt.Errorf("Could not parse MIN_POINT_AGE: %v", err)
 	}
 
-	resetInterval, err := time.ParseDuration(os.Getenv("DATADOG_COUNTER_RESET_INTERVAL"))
+	resetInterval, err := time.ParseDuration(os.Getenv("COUNTER_RESET_INTERVAL"))
 	if err != nil {
-		return nil, fmt.Errorf("Could not parse DATADOG_COUNTER_RESET_INTERVAL: %v", err)
+		return nil, fmt.Errorf("Could not parse COUNTER_RESET_INTERVAL: %v", err)
 	}
 
 	return tsbridge.NewConfig(ctx, &tsbridge.ConfigOptions{

--- a/app/metrics.yaml.example
+++ b/app/metrics.yaml.example
@@ -9,6 +9,13 @@ datadog_metrics:
     api_key: xxx
     application_key: xxx
     destination: another_stackdriver
+influxdb_metrics:
+  - name: request_count
+    query: "SELECT CUMULATIVE_SUM(COUNT(requests)) FROM nginx_access_log GROUP BY time(1m)"
+    database: telegraf
+    endpoint: http://localhost:8086
+    time_aggregated: true
+    cumulative: true
 stackdriver_destinations:
   - name: stackdriver
   - name: another_stackdriver

--- a/datadog/README.md
+++ b/datadog/README.md
@@ -23,7 +23,7 @@ metric:
     imported as a cumulative metric (a monotonically increasing counter). See
     [Cumulative metrics](#cumulative-metrics) section below for more details.
 
-All parameters are required, except for `cumulative` (that defaults to `false`).
+All parameters are required, except for `cumulative` (which defaults to `false`).
 
 For metrics that have measurements more often than every minute, you might
 also want to append the `.rollup()` function to avoid
@@ -36,7 +36,8 @@ Please keep in mind the following details about Datadog API:
     [300 queries per hour](https://docs.datadoghq.com/api/?lang=python#rate-limiting)
     that applies to the whole organization. Even if ts-bridge is the only user
     of the Query API, it still means you can only import 5 metrics if you are
-    querying every minute (which is the default). The limit can be raised.
+    querying every minute (which is the default). The limit can be
+    [raised](https://docs.datadoghq.com/api/?lang=bash#rate-limiting).
 *   If you are using a
     [rollup](https://docs.datadoghq.com/graphing/miscellaneous/functions/#rollup)
     function as part of your query, Datadog will return a single point per each

--- a/datadog/README.md
+++ b/datadog/README.md
@@ -1,0 +1,84 @@
+# Metric Source: Datadog
+
+To import a metric from Datadog, ts-bridge regularly runs a configured query
+against the
+[Datadog Query API](https://docs.datadoghq.com/api/?lang=python#query-time-series-points).
+
+Metrics imported from Datadog are defined in the `datadog_metrics` section of
+`app/metrics.yaml`. The following parameters need to be specified for each
+metric:
+
+*   `name`: base name of the metric. While exporting to Stackdriver, this name
+    will be prefixed with `custom.googleapis.com/datadog/`.
+*   `query`: Datadog query expression. This needs to return a single time series
+    (tags/labels are not supported yet).
+*   `api_key`: Datadog API key. See
+    [API and application keys](https://docs.datadoghq.com/api/?lang=go#overview)
+    on getting your API key.
+*   `application_key`: Datadog Application key.
+*   `destination`: name of the Stackdriver destination that query result will be
+    written to. Destinations need to be explicitly listed in the
+    `stackdriver_destinations` section of the configuration file.
+*   `cumulative`: a boolean flag describing whether query result should be
+    imported as a cumulative metric (a monotonically increasing counter). See
+    [Cumulative metrics](#cumulative-metrics) section below for more details.
+
+All parameters are required, except for `cumulative` (that defaults to `false`).
+
+For metrics that have measurements more often than every minute, you might
+also want to append the `.rollup()` function to avoid
+[aggregation](https://docs.datadoghq.com/graphing/faq/what-is-the-granularity-of-my-graphs-am-i-seeing-raw-data-or-aggregates-on-my-graph/)
+on Datadog's side.
+
+Please keep in mind the following details about Datadog API:
+
+*   There is an API rate limit of
+    [300 queries per hour](https://docs.datadoghq.com/api/?lang=python#rate-limiting)
+    that applies to the whole organization. Even if ts-bridge is the only user
+    of the Query API, it still means you can only import 5 metrics if you are
+    querying every minute (which is the default). The limit can be raised.
+*   If you are using a
+    [rollup](https://docs.datadoghq.com/graphing/miscellaneous/functions/#rollup)
+    function as part of your query, Datadog will return a single point per each
+    rollup interval. If rollup interval is longer than the importing period of
+    ts-bridge, some import operations will fetch 0 new points. For example, if
+    your query is producing a 10-minute ratio ( `xxx.rollup(sum, 600) /
+    yyy.rollup(sum, 600)`) and you are using the default importing period (1
+    minute), ts-bridge will still issue the query every minute, however Datadog
+    will only return a single point once every 10 minutes.
+*   If you are not using the `rollup` function, Datadog will return points at
+    maximum possible resolution (unless the query covers a very long time
+    interval). Please keep in mind that Datadog might return more than 1 point
+    per minute, and all points will be written to Stackdriver, even though
+    Stackdriver does not allow querying with
+    [alignment period](https://cloud.google.com/monitoring/charts/metrics-selector#alignment)
+    shorter than 1 minute.
+
+## Cumulative metrics
+
+Cumulative metrics are supported through Datadog's `cumsum()` function, which
+returns a monotonically increasing time series with a sum of all measurements
+since the given 'start time'.
+
+Often, for Datadog to provide a cumulative sum of all measurements,
+the `.as_count()` suffix needs to be appended to metric name. Otherwise
+measurements might be provided as per-second rates rather than exact counts.
+
+For example, to import the counter metric called `http_requests` as a
+cumulative metric to Stackdriver, you might configure the following query in
+ts-bridge (and set `cumulative` to `true`):
+
+    cumsum(sum:http_requests{*}.as_count().rollup(sum, 60))
+
+To unpack this:
+
+* `cumsum()` makes Datadog return a cumulative sum of measurements;
+* `sum:` prefix ensures that sum is used as the aggregation method if there
+  are multiple time series with the same metric name but different tags
+  (for example, reported from different machines);
+* `.as_count()` suffix gathers actual measurements rather than per-second
+  rates;
+* `.rollup(sum, 60)` aggregates values into 60-second intervals in case
+  there are multiple measurements for this metric reported per minute. See
+  [rollup documentation](https://docs.datadoghq.com/graphing/functions/rollup/)
+  for more.

--- a/influxdb/README.md
+++ b/influxdb/README.md
@@ -39,6 +39,11 @@ can be time aggregated as the following:
 
 `SELECT MEAN(free_disk_space) FROM sys_disk GROUP BY time(1m)`.
 
+When using queries with time aggregation, ts-bridge requires the
+`time_aggregated` flag to be set to `true` in the metric's YAML configuration.
+Otherwise, unexpected errors may arise when attempting to process these time
+series.
+
 Currently only InfluxDB 1.x series is supported.
 
 ## Cumulative metrics
@@ -58,6 +63,9 @@ effect in InfluxDB 1.6, a subquery can be defined instead:
 
 `SELECT CUMULATIVE_SUM(*) FROM (SELECT COUNT(request) FROM nginx_access_log
 GROUP BY time(1m))`.
+
+When using the above example, make sure to set `cumulative` to `true`, and
+`time_aggregated` to `true` if applicable.
 
 ### Zero value intervals
 

--- a/influxdb/README.md
+++ b/influxdb/README.md
@@ -14,9 +14,9 @@ metric:
     supported yet).
 *   `database`: InfluxDB database which the query is to be executed against.
 *   `endpoint`: base URL of your InfluxDB service.
-*   `auth.username`: username used for authentication. If none is provided,
-    no authentication will be passed.
-*   `auth.password`: password used for authentication.
+*   `username`: username used for authentication. If none is provided,
+    no credentials will be passed.
+*   `password`: password used for authentication.
 *   `time_aggregated`: a boolean flag describing whether the query is
     time aggregated (i.e. containing `GROUP BY time(x)`).
 *   `cumulative`: a boolean flag describing whether query result should be
@@ -26,8 +26,8 @@ metric:
     written to. Destinations need to be explicitly listed in the
     `stackdriver_destinations` section of the configuration file.
 
-All parameters other than `auth` and the boolean flags (`time_aggregated` and
-`cumulative` defaults to `false`) are required.
+All parameters other than `username`, `password` and the boolean flags
+(`time_aggregated` and `cumulative` defaults to `false`) are required.
 
 For metrics that have measurements more often than every minute, you might
 consider time aggregating the query to avoid importing too many points. For
@@ -42,7 +42,7 @@ can be time aggregated as the following:
 When using queries with time aggregation, ts-bridge requires the
 `time_aggregated` flag to be set to `true` in the metric's YAML configuration.
 Otherwise, unexpected errors may arise when attempting to process these time
-series.
+series as time aggregated queries can return duplicate timestamps.
 
 Currently only InfluxDB 1.x series is supported.
 
@@ -52,7 +52,7 @@ Cumulative metrics are supported through InfluxDB's `CUMULATIVE_SUM` function,
 which returns a montonically increasing time series with a sum of all
 measurements since the given 'start time'.
 
-This can be combined with aggregation to create counter like metrics. For
+This can be combined with aggregation to create counter-like metrics. For
 example, a popular metric required for SLIs may be:
 
 `SELECT CUMULATIVE_SUM(COUNT(requests)) FROM nginx_access_log GROUP BY time(1m)`.
@@ -65,14 +65,14 @@ effect in InfluxDB 1.6, a subquery can be defined instead:
 GROUP BY time(1m))`.
 
 When using the above example, make sure to set `cumulative` to `true`, and
-`time_aggregated` to `true` if applicable.
+`time_aggregated` to `true`.
 
 ### Zero value intervals
 
 For time aggregated cumulative queries, if no rows exist within the queried
 time frame, then the cumulative query will return no results. Often however,
-this is not an indication of having no data, but rather having timestamps with
-value 0. To avoid this, we can use the
+this is not an indication of having no data, but rather of having timestamps
+at each interval, but with value 0. To avoid this, we can use the
 [fill function](https://docs.influxdata.com/influxdb/v1.6/query_language/data_exploration/#group-by-time-intervals-and-fill)
 provided such as:
 

--- a/influxdb/README.md
+++ b/influxdb/README.md
@@ -1,0 +1,72 @@
+# Metric Source: InfluxDB
+
+To import a metric from InfluxDB, ts-bridge regularly runs a configured query
+against the [InfluxDB API](https://docs.influxdata.com/influxdb/v1.7/tools/api/).
+
+Metrics imported from InfluxDB are defined in the `influxdb_metrics` section of
+`app/metrics.yaml`. The following parameters need to be specified for each
+metric:
+
+*   `name`: base name of the metric. While exporting to Stackdriver, this name
+    will be prefixed with `custom.googleapis.com/influxdb/`.
+*   `query`: [InfluxQL](https://docs.influxdata.com/influxdb/v1.7/query_language/)
+    query. This needs to return a single time series (tags/labels are not
+    supported yet).
+*   `database`: InfluxDB database which the query is to be executed against.
+*   `endpoint`: base URL of your InfluxDB service.
+*   `auth.username`: username used for authentication. If none is provided,
+    no authentication will be passed.
+*   `auth.password`: password used for authentication.
+*   `time_aggregated`: a boolean flag describing whether the query is
+    time aggregated (i.e. containing `GROUP BY time(x)`).
+*   `cumulative`: a boolean flag describing whether query result should be
+    imported as a cumulative metric (a monotonically increasing counter). See
+    [Cumulative metrics](#cumulative-metrics) section below for more details.
+*   `destination`: name of the Stackdriver destination that query result will be
+    written to. Destinations need to be explicitly listed in the
+    `stackdriver_destinations` section of the configuration file.
+
+All parameters other than `auth` and the boolean flags (`time_aggregated` and
+`cumulative` defaults to `false`) are required.
+
+For metrics that have measurements more often than every minute, you might
+consider time aggregating the query to avoid importing too many points. For
+example, a gauge metric query such as:
+
+`SELECT free_disk_space FROM sys_disk`
+
+can be time aggregated as the following:
+
+`SELECT MEAN(free_disk_space) FROM sys_disk GROUP BY time(1m)`.
+
+Currently only InfluxDB 1.x series is supported.
+
+## Cumulative metrics
+
+Cumulative metrics are supported through InfluxDB's `CUMULATIVE_SUM` function,
+which returns a montonically increasing time series with a sum of all
+measurements since the given 'start time'.
+
+This can be combined with aggregation to create counter like metrics. For
+example, a popular metric required for SLIs may be:
+
+`SELECT CUMULATIVE_SUM(COUNT(requests)) FROM nginx_access_log GROUP BY time(1m)`.
+
+Note that the above style of nested aggregation (i.e. having a function inside
+of `CUMULATIVE_SUM()`) is only supported in InfluxDB 1.7. To achieve the same
+effect in InfluxDB 1.6, a subquery can be defined instead:
+
+`SELECT CUMULATIVE_SUM(*) FROM (SELECT COUNT(request) FROM nginx_access_log
+GROUP BY time(1m))`.
+
+### Zero value intervals
+
+For time aggregated cumulative queries, if no rows exist within the queried
+time frame, then the cumulative query will return no results. Often however,
+this is not an indication of having no data, but rather having timestamps with
+value 0. To avoid this, we can use the
+[fill function](https://docs.influxdata.com/influxdb/v1.6/query_language/data_exploration/#group-by-time-intervals-and-fill)
+provided such as:
+
+`SELECT CUMULATIVE_SUM(COUNT(requests)) FROM nginx_access_log GROUP BY time(1m)
+FILL(0)`.

--- a/stackdriver/adapter.go
+++ b/stackdriver/adapter.go
@@ -135,7 +135,7 @@ func (a *Adapter) setDescriptor(ctx context.Context, project, name string, desc 
 }
 
 // LatestTimestamp determines the timestamp of a latest point for a given metric in SD.
-// If metric does not exist, a timestamp which is `lookBackInterval` ago in the past is returned to backfill some data from Datadog.
+// If metric does not exist, a timestamp which is `lookBackInterval` ago in the past is returned to backfill some data.
 func (a *Adapter) LatestTimestamp(ctx context.Context, project, name string) (time.Time, error) {
 	latest := time.Now().Add(-a.lookBackInterval)
 


### PR DESCRIPTION
Add documentation for InfluxDB as a metric source, and share environment variables previously only used for Datadog.

This PR splits the documentation for source metrics into its own README since I felt like the root README was getting too long and complex with the new Influx documentations. Hopefully this is more understandable, but if not I can merge it back into the root README. :)