### PR TITLE
Add storage options support to datastore

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -212,10 +212,12 @@ func loadStorageEngine(ctx context.Context) (storage.Manager, error) {
 	storageEngine := os.Getenv("STORAGE_ENGINE")
 	switch storageEngine {
 	case "datastore":
-		return datastore.New(ctx), nil
+		datastoreManager := datastore.New(ctx, &datastore.Options{})
+		return datastoreManager, nil
 	case "":
 		log.Warn("Storage engine not configured, defaulting to GAE datastore.")
-		return datastore.New(ctx), nil
+		datastoreManager := datastore.New(ctx, &datastore.Options{})
+		return datastoreManager, nil
 	default:
 		return nil, fmt.Errorf("unknown storage engine selected: %s", storageEngine)
 	}

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -87,7 +87,7 @@ func makeTestServer(filename string) (*fixtureHandler, *httptest.Server) {
 
 func TestStackdriverDataErrors(t *testing.T) {
 	ctx := context.Background()
-	storage := datastore.New(ctx)
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	handler, server := makeTestServer("")
 	defer server.Close()
@@ -119,7 +119,7 @@ func TestStackdriverDataErrors(t *testing.T) {
 
 func TestStackdriverDataResponses(t *testing.T) {
 	ctx := context.Background()
-	storage := datastore.New(ctx)
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	for _, tt := range []struct {
 		filename string

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -211,6 +211,7 @@ func TestStackdriverDataResponses(t *testing.T) {
 
 func TestPointsGetFilteredOut(t *testing.T) {
 	ctx := context.Background()
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	_, server := makeTestServer("good.json")
 	defer server.Close()
@@ -229,7 +230,7 @@ func TestPointsGetFilteredOut(t *testing.T) {
 		m, _ := NewSourceMetric("metricname", &MetricConfig{Query: "metricquery"}, tt.minPointAge, time.Hour)
 		m.client.SetBaseUrl(server.URL)
 
-		_, ts, err := m.StackdriverData(ctx, tt.lastPoint, &datastore.StoredMetricRecord{})
+		_, ts, err := m.StackdriverData(ctx, tt.lastPoint, &datastore.StoredMetricRecord{Storage: storage})
 		if err != nil {
 			t.Errorf("expected no errors; got %v", err)
 		}
@@ -264,6 +265,7 @@ func TestFilterPoints(t *testing.T) {
 
 func TestStackdriverDataUnits(t *testing.T) {
 	ctx := context.Background()
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	handler, server := makeTestServer("")
 	defer server.Close()
@@ -279,7 +281,7 @@ func TestStackdriverDataUnits(t *testing.T) {
 		{"no_unit.json", ""},
 	} {
 		handler.filename = tt.filename
-		desc, _, err := m.StackdriverData(ctx, time.Now().Add(-time.Minute), &datastore.StoredMetricRecord{})
+		desc, _, err := m.StackdriverData(ctx, time.Now().Add(-time.Minute), &datastore.StoredMetricRecord{Storage: storage})
 		if err != nil {
 			t.Errorf("%s: expected no errors; got %v", tt.filename, err)
 		}

--- a/datastore/datastore_manager.go
+++ b/datastore/datastore_manager.go
@@ -24,8 +24,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Options holds settings specific to datastore
+type Options struct {
+}
+
 // New initializes the Manager struct implementing a generic storage.Manager interface
-func New(ctx context.Context) *Manager {
+func New(ctx context.Context, options *Options) *Manager {
 	dsClient, err := datastore.NewClient(ctx, fetchProjectID())
 	if err != nil {
 		log.Fatalf("could not create datastore client: %v", err)

--- a/datastore/datastore_manager_test.go
+++ b/datastore/datastore_manager_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestCleanupDatastoreMetricRecords(t *testing.T) {
 	ctx := context.Background()
-	storageManager := New(ctx)
+	storageManager := New(ctx, &Options{})
 
 	for _, name := range []string{"metric1", "metric2"} {
 		r := StoredMetricRecord{

--- a/datastore/datastore_record_test.go
+++ b/datastore/datastore_record_test.go
@@ -47,8 +47,7 @@ var metricRecordTests = []struct {
 
 func TestDatastoreMetricRecords(t *testing.T) {
 	ctx := context.Background()
-
-	storageManager := New(ctx)
+	storageManager := New(ctx, &Options{})
 
 	for _, tt := range metricRecordTests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/influxdb/metric_test.go
+++ b/influxdb/metric_test.go
@@ -269,7 +269,7 @@ func TestStackdriverDataQuery(t *testing.T) {
 
 func TestStackdriverDataErrors(t *testing.T) {
 	ctx := context.Background()
-	storage := datastore.New(ctx)
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	handler, server := makeTestServer("")
 	defer server.Close()

--- a/influxdb/metric_test.go
+++ b/influxdb/metric_test.go
@@ -342,6 +342,7 @@ func TestStackdriverDataErrors(t *testing.T) {
 
 func TestStackdriverDataGaugeResponse(t *testing.T) {
 	ctx := context.Background()
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	_, server := makeTestServer("good.json")
 	defer server.Close()
@@ -353,7 +354,7 @@ func TestStackdriverDataGaugeResponse(t *testing.T) {
 	m, _ := NewSourceMetric("metricname", c, time.Second, time.Hour)
 	// The lastTime time passed here is irrelevant, as we stubbed what the
 	// query returns.
-	desc, ts, err := m.StackdriverData(ctx, time.Now(), &datastore.StoredMetricRecord{})
+	desc, ts, err := m.StackdriverData(ctx, time.Now(), &datastore.StoredMetricRecord{Storage: storage})
 	if err != nil {
 		t.Fatalf("unexpected StackdriverData error: %v", err)
 	}
@@ -410,6 +411,7 @@ func TestStackdriverDataGaugeResponse(t *testing.T) {
 
 func TestStackdriverDataTimeAggGaugeResponse(t *testing.T) {
 	ctx := context.Background()
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	_, server := makeTestServer("good.json")
 	defer server.Close()
@@ -428,7 +430,7 @@ func TestStackdriverDataTimeAggGaugeResponse(t *testing.T) {
 	// Influx query.
 	lastPoint := time.Unix(0, 1015000000000)                          // (1015s)
 	timeNow = func() time.Time { return time.Unix(0, 1035000000000) } // (1035s)
-	desc, ts, err := m.StackdriverData(ctx, lastPoint, &datastore.StoredMetricRecord{})
+	desc, ts, err := m.StackdriverData(ctx, lastPoint, &datastore.StoredMetricRecord{Storage: storage})
 	if err != nil {
 		t.Fatalf("unexpected StackdriverData error: %v", err)
 	}

--- a/tsbridge/config_test.go
+++ b/tsbridge/config_test.go
@@ -33,7 +33,7 @@ func setProjectID(projectID string) {
 
 func TestNewConfigSimple(t *testing.T) {
 	ctx := context.Background()
-	storage := datastore.New(ctx)
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	cfg, err := NewConfig(ctx, &ConfigOptions{Filename: "testdata/valid.yaml", Storage: storage})
 	if err != nil {
@@ -66,6 +66,7 @@ func TestNewConfigSimple(t *testing.T) {
 
 func TestNewConfigFailedValidation(t *testing.T) {
 	ctx := context.Background()
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	for _, tt := range []struct {
 		filename string
@@ -78,7 +79,7 @@ func TestNewConfigFailedValidation(t *testing.T) {
 		{"invalid_name.yaml", "configuration file validation error"},
 		{"no_influxdb_query.yaml", "configuration file validation error"},
 	} {
-		_, err := NewConfig(ctx, &ConfigOptions{Filename: filepath.Join("testdata", tt.filename), Storage: datastore.New(ctx)})
+		_, err := NewConfig(ctx, &ConfigOptions{Filename: filepath.Join("testdata", tt.filename), Storage: storage})
 		if !strings.Contains(err.Error(), tt.wantErr) {
 			t.Errorf("expected NewConfig error '%v'; got '%v'", tt.wantErr, err)
 		}

--- a/tsbridge/metric_test.go
+++ b/tsbridge/metric_test.go
@@ -112,7 +112,7 @@ var metricUpdateTests = []struct {
 
 func TestMetricUpdate(t *testing.T) {
 	ctx := context.Background()
-	storage := datastore.New(ctx)
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	for _, tt := range metricUpdateTests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -157,6 +157,7 @@ func TestMetricUpdate(t *testing.T) {
 
 func TestMetricImportLatencyMetric(t *testing.T) {
 	ctx := context.Background()
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -165,7 +166,7 @@ func TestMetricImportLatencyMetric(t *testing.T) {
 	mockSource.EXPECT().Query()
 	mockSource.EXPECT().StackdriverName().MaxTimes(100).Return("sd-metricname")
 
-	m, err := NewMetric(ctx, "metricname", mockSource, "sd-project", datastore.New(ctx))
+	m, err := NewMetric(ctx, "metricname", mockSource, "sd-project", storage)
 	if err != nil {
 		t.Fatalf("error while creating metric: %v", err)
 	}
@@ -208,7 +209,7 @@ var updateAllMetricsTests = []struct {
 
 func TestUpdateAllMetrics(t *testing.T) {
 	ctx := context.Background()
-	storage := datastore.New(ctx)
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	for _, tt := range updateAllMetricsTests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -268,7 +269,7 @@ func TestUpdateAllMetrics(t *testing.T) {
 
 func TestUpdateAllMetricsErrors(t *testing.T) {
 	ctx := context.Background()
-	storage := datastore.New(ctx)
+	storage := datastore.New(ctx, &datastore.Options{})
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
- This PR is just a small refactor that adds `Options` struct to Datastore, abstracting the storage options initialisation, as we'll need support for additional options later, esp. for different stores that need much more options.