### PR TITLE
Adding CLI flags & 12-factor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,16 @@ minute.
 
 ## Global settings
 
-Some other settings can be set globally as App Engine environment variables via
-the `env_variables` section of `app/app.yaml`.
+Some other settings can be set globally as environment variables or command-line flags.
+In case of AppEngine variables are configured in the `env_variables` section of `app/app.yaml`.
 
-*   `CONFIG_FILE`: name of the metric configuration file (`metrics.yaml`).
-*   `SD_LOOKBACK_INTERVAL`: time interval used while searching for recent data
-    in Stackdriver. This is also the default backfill interval for when no
-    recent points are found. This interval should be kept reasonably short to
-    avoid fetching too much data from Stackdriver on each update.
+*   `DEBUG` (`--debug`): enable debug logging.
+*   `PORT` (`--port`): ts-bridge server port.
+*   `CONFIG_FILE` (`--metric-config`): name of the metric configuration file (`metrics.yaml`).
+*   `SD_LOOKBACK_INTERVAL` (`--sd-lookback-interval`): time interval used while 
+    searching for recent data in Stackdriver. This is also the default backfill
+    interval for when no recent points are found. This interval should be kept 
+    reasonably short to avoid fetching too much data from Stackdriver on each update.
     *   You might be tempted to increase this significantly to backfill historic
         values. Please keep in mind that Stackdriver
         [does not allow](https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts)
@@ -193,29 +195,29 @@ the `env_variables` section of `app/app.yaml`.
         [keep the number of points in each response below ~300](https://docs.datadoghq.com/getting_started/from_the_query_to_the_graph/#how).
         This means that a single request can only cover a time period of 5 hours
         if you are aiming to get a point per minute.
-*   `UPDATE_TIMEOUT`: the total time that updating all metrics is allowed to
-    take. The incoming HTTP request from App Engine Cron will fail if it takes
-    longer than this, and a subsequent update will be triggered again.
-*   `UPDATE_PARALLELISM`: number of metric updates that are performed in
-    parallel. Parallel updates are scheduled using goroutines and still happen
-    in the context of a single incoming HTTP request, and setting this value too
-    high might result in the App Engine instance running out of RAM.
-*   `MIN_POINT_AGE`: minimum age of a data point returned by a metric source
-    that makes it eligible for being written. Points that are very fresh
-    (default is 1.5 minutes) are ignored, since the metric source might return
+*   `UPDATE_TIMEOUT` (`--update-timeout`): the total time that updating all metrics
+    is allowed to take. The incoming HTTP request from App Engine Cron will fail if
+    it takes longer than this, and a subsequent update will be triggered again.
+*   `UPDATE_PARALLELISM` (`--update-parallelism`): number of metric updates that
+    are performed in parallel. Parallel updates are scheduled using goroutines and
+    still happen in the context of a single incoming HTTP request, and setting this
+    value too high might result in the App Engine instance running out of RAM.
+*   `MIN_POINT_AGE` (`--min-point-age`): minimum age of a data point returned by a
+    metric source that makes it eligible for being written. Points that are very 
+    fresh (default is 1.5 minutes) are ignored, since the metric source might return
     incomplete data for them if some input data is delayed.
-*   `COUNTER_RESET_INTERVAL`: while importing counters, ts-bridge needs
-    to reset 'start time' regularly to keep the query time window small enough.
-    This parameter defines how often a new start time is chosen, and defaults
-    to 30 minutes. See [Cumulative metrics](#cumulative-metrics) section below
-    for more details.
-*   `STORAGE_ENGINE`: storage engine to use for storing metric metadata, 
-    defaults to `datastore`.  
+*   `COUNTER_RESET_INTERVAL` (`--counter-reset-interval`): while importing counters,
+    ts-bridge needs to reset 'start time' regularly to keep the query time window 
+    small enough. This parameter defines how often a new start time is chosen, and
+    defaults to 30 minutes. See [Cumulative metrics](#cumulative-metrics) section 
+    below for more details.
+*   `STORAGE_ENGINE` (`--storage-engine`): storage engine to use for storing metric
+    metadata, defaults to `datastore`.  
     * `datastore` - use AppEngine Datastore
     * `boltdb` - use [BoltDB](https://github.com/etcd-io/bbolt) via [BoltHold](https://github.com/timshannon/bolthold)
-        * `BOLTDB_PATH` - path to BoltDB store, e.g. `/data/bolt.db` (defaults to `$PWD/bolt.db`)
-*   `ENABLE_STATUS_PAGE`: can be set to 'yes' to enable the status web page
-    (disabled by default).
+        * `BOLTDB_PATH` (`--boltdb-path`) - path to BoltDB store, e.g. `/data/bolt.db` (defaults to `$PWD/bolt.db`)
+*   `ENABLE_STATUS_PAGE` (`--enable-status-page`): can be set to 'yes' to enable
+    the status web page (disabled by default).
 
 You can use `--env_var` flag to override these environment variables while
 running the app via `dev_appserver.py`.

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -11,8 +11,8 @@ env_variables:
   # later retried.
   UPDATE_TIMEOUT: "5m"
   # Name of the Stackdriver project that will be used to report internal ts-bridge metrics (import latencies,
-  # metric age). If empty, the project hosting the ts-bridge App Engine app itself will be used.
-  SD_PROJECT_FOR_INTERNAL_METRICS: ""
+  # metric age). If not set, the project hosting the ts-bridge App Engine app itself will be used.
+  #SD_PROJECT_FOR_INTERNAL_METRICS: "my-project"
   # Number of metrics to update in parallel. Must be between 1 and 100 (chosen arbitrarily).
   UPDATE_PARALLELISM: 1
   # Points received from metric sources that are too fresh will be discarded to allow data to settle before being imported.
@@ -25,6 +25,8 @@ env_variables:
   # Select storage engine to keep the metrics metadata in, currently supported options:
   # "datastore" - AppEngine Datastore
   STORAGE_ENGINE: "datastore"
+  # Project to use for Datastore. If not set, the project hosting the ts-bridge App Engine app itself will be used.
+  #DATASTORE_PROJECT: "my-project"
   # Uncomment to enable the status web page.
   #ENABLE_STATUS_PAGE: "yes"
 

--- a/app/main.go
+++ b/app/main.go
@@ -63,7 +63,7 @@ func sync(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(ctx, t)
 	defer cancel()
 
-	if isAppEngine() && r.Header.Get("X-Appengine-Cron") != "true" {
+	if env.IsAppEngine() && r.Header.Get("X-Appengine-Cron") != "true" {
 		http.Error(w, "Only cron requests are allowed here", http.StatusUnauthorized)
 		return
 	}
@@ -116,7 +116,7 @@ func sync(w http.ResponseWriter, r *http.Request) {
 func cleanup(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	if isAppEngine() && r.Header.Get("X-Appengine-Cron") != "true" {
+	if env.IsAppEngine() && r.Header.Get("X-Appengine-Cron") != "true" {
 		http.Error(w, "Only cron requests are allowed here", http.StatusUnauthorized)
 		return
 	}
@@ -216,7 +216,7 @@ func loadStorageEngine(ctx context.Context) (storage.Manager, error) {
 		datastoreManager := datastore.New(ctx, &datastore.Options{})
 		return datastoreManager, nil
 	case "boltdb":
-		if isAppEngine() {
+		if env.IsAppEngine() {
 			return nil, fmt.Errorf("BoltDB storage is not supported on AppEngine")
 		}
 		opts := &boltdb.Options{DBPath: os.Getenv("BOLTDB_PATH")}
@@ -229,10 +229,4 @@ func loadStorageEngine(ctx context.Context) (storage.Manager, error) {
 	default:
 		return nil, fmt.Errorf("unknown storage engine selected: %s", storageEngine)
 	}
-}
-
-// Check if we're running in AppEngine by checking GAE_ENV variable
-func isAppEngine() bool {
-	_, set := os.LookupEnv("GAE_ENV")
-	return set
 }

--- a/datastore/emulator.go
+++ b/datastore/emulator.go
@@ -108,7 +108,12 @@ func Emulator(ctx context.Context) <-chan struct{} {
 	}
 
 	// This is emulating the old `aetest` framework that has a hardcoded "testapp" value for project
-	if err := os.Setenv("GOOGLE_CLOUD_PROJECT", fmt.Sprintf(fakeProjectID)); err != nil {
+	if err := os.Setenv("GOOGLE_CLOUD_PROJECT", fakeProjectID); err != nil {
+		log.Errorf("couldn't set env GOOGLE_CLOUD_PROJECT: %v", err)
+	}
+
+	// This env is set to pretend we're running on AppEngine
+	if err := os.Setenv("GAE_ENV", "standard"); err != nil {
 		log.Errorf("couldn't set env GOOGLE_CLOUD_PROJECT: %v", err)
 	}
 

--- a/datastore/emulator.go
+++ b/datastore/emulator.go
@@ -109,12 +109,12 @@ func Emulator(ctx context.Context) <-chan struct{} {
 
 	// This is emulating the old `aetest` framework that has a hardcoded "testapp" value for project
 	if err := os.Setenv("GOOGLE_CLOUD_PROJECT", fakeProjectID); err != nil {
-		log.Errorf("couldn't set env GOOGLE_CLOUD_PROJECT: %v", err)
+		log.Fatalf("couldn't set env GOOGLE_CLOUD_PROJECT: %v", err)
 	}
 
 	// This env is set to pretend we're running on AppEngine
 	if err := os.Setenv("GAE_ENV", "standard"); err != nil {
-		log.Errorf("couldn't set env GOOGLE_CLOUD_PROJECT: %v", err)
+		log.Fatalf("couldn't set env GAE_ENV: %v", err)
 	}
 
 	return quit
@@ -123,7 +123,7 @@ func Emulator(ctx context.Context) <-chan struct{} {
 func findEmulatorPath() string {
 	path, err := exec.LookPath("gcloud")
 	if err != nil {
-		log.Fatalf("Couldn't determine gcloud path")
+		log.Fatalf("Couldn't determine gcloud path: %v", err)
 	}
 
 	return strings.Replace(path, "bin/gcloud", "platform/cloud-datastore-emulator/cloud_datastore_emulator", 1)

--- a/env/env.go
+++ b/env/env.go
@@ -1,0 +1,17 @@
+package env
+
+import "os"
+
+// TODO(temikus): this should really be a standalone lib, something similar to https://github.com/googleapis/google-cloud-ruby/tree/master/google-cloud-env
+
+// IsAppEngine checks if the code is running in AppEngine by checking GAE_ENV variable
+func IsAppEngine() bool {
+	_, set := os.LookupEnv("GAE_ENV")
+	return set
+}
+
+// AppEngineProject returns the cloud project GAE App is running in
+// 	 Note: this is the official way to get this information within GAE.
+func AppEngineProject() string {
+	return os.Getenv("GOOGLE_CLOUD_PROJECT")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	cloud.google.com/go v0.65.0
 	cloud.google.com/go/datastore v1.2.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.4
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aws/aws-sdk-go v1.34.13 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
@@ -27,6 +29,7 @@ require (
 	google.golang.org/api v0.30.0
 	google.golang.org/genproto v0.0.0-20200829155447-2bf3329a0021
 	google.golang.org/grpc v1.31.1
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/validator.v2 v2.0.0-20200605151824-2b28d334fa05
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,10 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.13 h1:wwNWSUh4FGJxXVOVVNj2lWI8wTe5hK8sGWlK7ziEcgg=
 github.com/aws/aws-sdk-go v1.34.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -152,6 +156,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -448,6 +453,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/stackdriver/adapter.go
+++ b/stackdriver/adapter.go
@@ -17,7 +17,6 @@ package stackdriver
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -48,18 +47,15 @@ type Adapter struct {
 }
 
 // NewAdapter returns a new Stackdriver adapter.
-func NewAdapter(ctx context.Context) (*Adapter, error) {
+func NewAdapter(ctx context.Context, lookbackInterval time.Duration) (*Adapter, error) {
 	c, err := newClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	d, err := time.ParseDuration(os.Getenv("SD_LOOKBACK_INTERVAL"))
-	if err != nil {
-		return nil, fmt.Errorf("Could not parse SD_LOOKBACK_INTERVAL duration: %v", err)
-	}
+	log.Debugf("StackDriver client/lookback configured: %v/%v", c, lookbackInterval)
 
-	return &Adapter{c, d}, nil
+	return &Adapter{c, lookbackInterval}, nil
 }
 
 // Close closes the underlying metric client.


### PR DESCRIPTION
- getting rid of all env getters and validations and putting them into one single place
- doing simple flag-based logic to set Env instead of importing a large dep like Kong/Kingpin/Viper
	- there is 2 cons to the approach but I consider them acceptable:
		- some extra/code plumbing needed (see `flags.go`)
		- env will override flags if set

BREAKING 💥: if we don't want option to be set we don't set it at all instead of setting it to empty. I think it's worth the possible light breakage as this makes all env options explicit, instead of using brittle check-if-empty logic.

@Dnefedkin FYI
