### PR TITLE
Add a simple health check endpoint

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -113,6 +113,7 @@ func main() {
 	http.HandleFunc("/", h.Index)
 	http.HandleFunc("/sync", h.Sync)
 	http.HandleFunc("/cleanup", h.Cleanup)
+	http.HandleFunc("/health", h.Health)
 
 	// Run a cleanup on startup
 	log.Debugf("Performing startup cleanup...")

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -1,0 +1,33 @@
+package web
+
+import (
+	"github.com/google/ts-bridge/tsbridge"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandler(t *testing.T) {
+	config := tsbridge.NewConfig(&tsbridge.ConfigOptions{})
+	h := NewHandler(config)
+
+	req, err := http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	adapter := http.HandlerFunc(h.Health)
+	adapter.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	expected := `{"status":"ok"}`
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}


### PR DESCRIPTION
This adds a simple health check endpoint to TS-Bridge

Currently it just returns `status: ok` (i.e. a simple heartbeat that the binary is running) but can be extended later. This seems to be enough for now as we fatally exit on all conditions that I know of that could cause an application to stall, but the binary to keep running.

FYI @Dnefedkin 