### PR TITLE
Run Go unit tests in different versions

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -14,24 +14,38 @@ on:
     types: [created, edited, published]
 
 jobs:
-  install-and-run:
-    name: Install go and run tests
+  project-go-version:
+    name: Export current go version
     runs-on: ubuntu-latest
-    env:
-      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    outputs:
+      go-version: ${{ steps.go.outputs.go-version }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
 
       - name: Set Go version
-        run: echo "go-version=$(cat .go-version)" >> $GITHUB_ENV
+        id: go
+        run: echo "::set-output name=go-version::$(cat .go-version)"
 
-      - name: Set up Go according to .go-version
+
+  install-and-run:
+    name: Install go and run tests
+    needs: project-go-version
+    runs-on: ubuntu-latest
+    env:
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    strategy:
+      matrix:
+        go-version: ["${{needs.project-go-version.outputs.go-version}}", "^1.*", "1.14.x"]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Go with ${{ matrix.go-version }}
         uses: actions/setup-go@v2
-        # TODO(https://github.com/google/ts-bridge/issues/70): Test with
-        # different versions of Go.
         with:
-          go-version: ${{ env.go-version }}
+          go-version: ${{ matrix.go-version }}
+          stable: false
 
       - name: Set up gcloud datastore emulator
         # JRE is needed for the datastore emulator

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -14,8 +14,10 @@ on:
     types: [created, edited, published]
 
 jobs:
+  # This separate step is required for the project's go-version to be exported
+  # for use in the following job's matrix.
   project-go-version:
-    name: Export current go version
+    name: Export project go version
     runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.go.outputs.go-version }}
@@ -27,16 +29,16 @@ jobs:
         id: go
         run: echo "::set-output name=go-version::$(cat .go-version)"
 
-
   install-and-run:
-    name: Tests
+    name: Tests Go
     needs: project-go-version
     runs-on: ubuntu-latest
     env:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     strategy:
       matrix:
-        go-version: ["${{needs.project-go-version.outputs.go-version}}", "^1.*", "1.14.x"]
+        # Versions tested: Project version, version before latest, latest, pre-release
+        go-version: ["${{needs.project-go-version.outputs.go-version}}", "1.14.x", "1.15.x"]
         include:
           - go-version: "1.16.0-beta1"
             prerelease: true
@@ -60,6 +62,7 @@ jobs:
           sudo apt-get install openjdk-8-jre-headless
 
       - name: Run tests
+        # Allow tests to fail pre-release Go versions
         continue-on-error: ${{ matrix.prerelease }}
         run: |
           source $HOME/google-cloud-sdk/path.bash.inc

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "::set-output name=go-version::$(cat .go-version)"
 
   install-and-run:
-    name: Tests Go
+    name: Tests Go ${{ matrix.go-version }} ${{matrix.name}}
     needs: project-go-version
     runs-on: ubuntu-latest
     env:
@@ -40,7 +40,8 @@ jobs:
         # Versions tested: Project version, version before latest, latest, pre-release
         go-version: ["${{needs.project-go-version.outputs.go-version}}", "1.14.x", "1.15.x"]
         include:
-          - go-version: "1.16.0-beta1"
+          - name: "(Pre-release)"
+            go-version: "1.16.0-beta1"
             prerelease: true
       # Prevent GHA from cancelling other matrix jobs if one fails
       fail-fast: false

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -39,6 +39,8 @@ jobs:
       matrix:
         # Versions tested: Project version, version before latest, latest, pre-release
         go-version: ["${{needs.project-go-version.outputs.go-version}}", "1.14.x", "1.15.x"]
+        # Pre-release tests provide early feedback if something breaks in the
+        # next Go release.
         include:
           - name: "(Pre-release)"
             go-version: "1.16.0-beta1"
@@ -63,7 +65,12 @@ jobs:
           sudo apt-get install openjdk-8-jre-headless
 
       - name: Run tests
-        # Allow tests to fail pre-release Go versions
+        # Since pre-release branches can be unstable we ignore test errors and
+        # still mark the workflow run as successful. This prevents pre-release
+        # test failures from blocking PR merges.
+
+        # TODO: Remove below setting when workflows have "allow-failure" option.
+        # See: https://github.com/actions/toolkit/issues/399
         continue-on-error: ${{ matrix.prerelease }}
         run: |
           source $HOME/google-cloud-sdk/path.bash.inc

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -36,7 +36,7 @@ jobs:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     strategy:
       matrix:
-        go-version: ["${{needs.project-go-version.outputs.go-version}}", "^1.*", "1.14.x"]
+        go-version: ["${{needs.project-go-version.outputs.go-version}}", "^1.*", "1.14.x", "1.16.0-beta1"]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-          stable: false
+          stable: 'false'
 
       - name: Set up gcloud datastore emulator
         # JRE is needed for the datastore emulator

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -29,9 +29,8 @@ jobs:
 
 
   install-and-run:
-    name: Install go and run tests
+    name: Tests
     needs: project-go-version
-    if: always()
     runs-on: ubuntu-latest
     env:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
@@ -41,6 +40,8 @@ jobs:
         include:
           - go-version: "1.16.0-beta1"
             prerelease: true
+      # Prevent GHA from cancelling other matrix jobs if one fails
+      fail-fast: false
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -31,12 +31,16 @@ jobs:
   install-and-run:
     name: Install go and run tests
     needs: project-go-version
+    if: always()
     runs-on: ubuntu-latest
     env:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     strategy:
       matrix:
-        go-version: ["${{needs.project-go-version.outputs.go-version}}", "^1.*", "1.14.x", "1.16.0-beta1"]
+        go-version: ["${{needs.project-go-version.outputs.go-version}}", "^1.*", "1.14.x"]
+        include:
+          - go-version: "1.16.0-beta1"
+            prerelease: true
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -55,6 +59,7 @@ jobs:
           sudo apt-get install openjdk-8-jre-headless
 
       - name: Run tests
+        continue-on-error: ${{ matrix.prerelease }}
         run: |
           source $HOME/google-cloud-sdk/path.bash.inc
           go mod download
@@ -65,6 +70,7 @@ jobs:
           go generate ./...
 
       - name: Annotate Tests
+        # Annotate failed tests
         if: always()
         uses: guyarb/golang-test-annotations@v0.2.0
         with:

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -95,6 +95,7 @@ func TestStackdriverDataErrors(t *testing.T) {
 	m.client.SetBaseUrl(server.URL)
 
 	// At this point HTTP server returns 404 to all requests, so we might as well test error handling.
+	t.Error("expected an error when server returns 404")
 	if _, _, err := m.StackdriverData(ctx, time.Now().Add(-time.Minute), &datastore.StoredMetricRecord{Storage: storage}); err == nil {
 		t.Error("expected an error when server returns 404")
 	}

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -95,7 +95,6 @@ func TestStackdriverDataErrors(t *testing.T) {
 	m.client.SetBaseUrl(server.URL)
 
 	// At this point HTTP server returns 404 to all requests, so we might as well test error handling.
-	t.Error("expected an error when server returns 404")
 	if _, _, err := m.StackdriverData(ctx, time.Now().Add(-time.Minute), &datastore.StoredMetricRecord{Storage: storage}); err == nil {
 		t.Error("expected an error when server returns 404")
 	}


### PR DESCRIPTION
Adding functionality to run Go tests for the following versions:

- latest (1.15.x)
- major release before latest (1.14.x)
- project version (from .go-version)
- prerelease version (1.16beta1)

In order to use the project version in a job's matrix, I moved parsing of go-version into a separate job which the test job depends on.

All matrix jobs will run even if another matrix job fails. This is so that tests for different versions can all run independently.

The prerelease version has `continue-on-error` set to true so that the workflow will show as SUCCESSFUL (green tick) even if tests for the prerelease fails. The failed tests will still be annotated in the workflow summary. 