### PR TITLE
Add Dependabot version updates for Docker, Github Actions, Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Configures Dependabot to update package dependencies.
+version: 2
+updates:
+  # Check for version updates for Docker
+  - package-ecosystem: "docker"
+    # Location of Dockerfile
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    # Set to '/' to check for workflows in .github/workflows
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Keep Go modules up to date
+  - package-ecosystem: "gomod"
+    # Location of go.mod
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,21 @@
-# Configures Dependabot to update package dependencies.
+# Configures Dependabot to create pull requests when package dependency updates are found.
 version: 2
 updates:
-  # Check for version updates for Docker
+  # Keep Docker image layers up to date.
   - package-ecosystem: "docker"
     # Location of Dockerfile
     directory: "/"
     schedule:
       interval: "weekly"
 
-  # Keep GitHub Actions up to date
+  # Keep GitHub Actions up to date.
   - package-ecosystem: "github-actions"
     # Set to '/' to check for workflows in .github/workflows
     directory: "/"
     schedule:
       interval: "weekly"
 
-  # Keep Go modules up to date
+  # Keep Go modules up to date.
   - package-ecosystem: "gomod"
     # Location of go.mod
     directory: "/"


### PR DESCRIPTION
After merging this file, [Dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates) will check for version updates every week and create pull requests when an update is found. 

Default config is as follows:
- Dependabot will open a maximum of five pull requests for version updates at any time.
- Dependabot will run every Monday at 05:00 UTC. 
- Branch: default

Note: this config file only manages *version* updates. *Security* updates are configured separately on GitHub settings. See also: https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/about-dependabot-security-updates