### PR TITLE
Fix typo in build trigger

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, reopened, edited, synchronised]
+    types: [opened, reopened, edited, synchronize]
     branches:
       - master
   # Also trigger when a new release has been created.
@@ -38,7 +38,12 @@ jobs:
     strategy:
       matrix:
         # Versions tested: Project version, version before latest, latest, pre-release
-        go-version: ["${{needs.project-go-version.outputs.go-version}}", "1.14.x", "1.15.x"]
+        go-version:
+          [
+            "${{needs.project-go-version.outputs.go-version}}",
+            "1.14.x",
+            "1.15.x",
+          ]
         # Pre-release tests provide early feedback if something breaks in the
         # next Go release.
         include:
@@ -55,7 +60,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-          stable: 'false'
+          stable: "false"
 
       - name: Set up gcloud datastore emulator
         # JRE is needed for the datastore emulator

--- a/.github/workflows/test-docker-image-build.yml
+++ b/.github/workflows/test-docker-image-build.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     # Allow manual triggers via GitHub Actions tab
   pull_request:
-    types: [opened, reopened, edited, synchronised]
+    types: [opened, reopened, edited, synchronize]
     branches:
       - master
 jobs:


### PR DESCRIPTION
There was a typo in the pull_request trigger for two of the GitHub Actions.

For more information on build triggers, see: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request