### PR TITLE
Add local profiler and refactor LoadStorageEngine to be outside of syncLoop

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -79,13 +79,21 @@ jobs:
         # See: https://github.com/actions/toolkit/issues/399
         continue-on-error: ${{ matrix.prerelease }}
         run: |
+          echo "Sourcing Google Cloud SDK path helper..."
           source $HOME/google-cloud-sdk/path.bash.inc
+          echo "Downloading go modules..."
           go mod download
-          go install github.com/go-bindata/go-bindata/v3/go-bindata
-          go install github.com/golang/mock/mockgen
-          go test -v -timeout=30s -json ./... > test.json
+          echo "Installing development deps..."
+          go install -v github.com/go-bindata/go-bindata/v3/go-bindata
+          go install -v github.com/golang/mock/mockgen
+          echo "Running go tests..."
+          go test -v -timeout=60s ./...
+          echo "Running go tests again with JSON output for annotations..."
+          go test -v -timeout=60s -json ./... > test.json
+          echo "Running gofmt..."
           gofmt -w $(go list -f '{{.Dir}}' ./...)
-          go generate ./...
+          echo "Running go generate..."
+          go generate -v ./...
 
       - name: Annotate Tests
         # Annotate failed tests

--- a/app/main.go
+++ b/app/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/ts-bridge/version"
 
 	"cloud.google.com/go/profiler"
+	"github.com/pkg/profile"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -97,6 +98,10 @@ var (
 	monitoringBackends = kingpin.Flag(
 		"stats-metric-exporters", "Monitoring backend(s) for internal metrics.",
 	).Envar("STATS_METRIC_EXPORTERS").Default("stackdriver").Enums("prometheus", "stackdriver")
+
+	enableLocalCPUProfiler = kingpin.Flag(
+		"enable-local-cpu-profiler", "Enable local CPU Profiler",
+	).Envar("ENABLE_LOCAL_CPU_PROFILER").Default("false").Bool()
 )
 
 func main() {
@@ -121,6 +126,11 @@ func main() {
 
 	if err := validateFlags(); err != nil {
 		log.Fatalf("Invalid flags: %v", err)
+	}
+
+	if *enableLocalCPUProfiler {
+		log.Debugf("CPU Profiler enabled.")
+		defer profile.Start(profile.CPUProfile, profile.ProfilePath(".")).Stop()
 	}
 
 	config := tsbridge.NewConfig(&tsbridge.ConfigOptions{

--- a/datadog/metric_test.go
+++ b/datadog/metric_test.go
@@ -39,7 +39,7 @@ import (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Save the emulator's quit channel.
-	quit := datastore.Emulator(ctx)
+	quit := datastore.Emulator(ctx, true)
 	code := m.Run()
 	cancel()
 	// Wait for channel close before exiting the test suite

--- a/datastore/datastore_record_test.go
+++ b/datastore/datastore_record_test.go
@@ -26,7 +26,7 @@ import (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Save the emulator's quit channel.
-	quit := Emulator(ctx)
+	quit := Emulator(ctx, true)
 	code := m.Run()
 	cancel()
 	// Wait for channel close before exiting the test suite

--- a/datastore/emulator.go
+++ b/datastore/emulator.go
@@ -18,11 +18,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"os"
 	"os/exec"
@@ -41,13 +42,13 @@ const fakeProjectID = "testapp"
 //
 //	 ctx, cancel := context.WithCancel(context.Background())
 //	 // Save the emulator's quit channel.
-//	 quit := Emulator(ctx)
+//	 quit := Emulator(ctx, true)
 //	 code := m.Run()
 //	 cancel()
 //	 // Wait for channel close
 //	 <-quit
 //
-func Emulator(ctx context.Context) <-chan struct{} {
+func Emulator(ctx context.Context, setGAE bool) <-chan struct{} {
 
 	// Create a child logger and set it to process newlines since emulator gives a lot of output.
 	l := log.WithContext(ctx)
@@ -113,8 +114,10 @@ func Emulator(ctx context.Context) <-chan struct{} {
 	}
 
 	// This env is set to pretend we're running on AppEngine
-	if err := os.Setenv("GAE_ENV", "standard"); err != nil {
-		log.Fatalf("couldn't set env GAE_ENV: %v", err)
+	if setGAE {
+		if err := os.Setenv("GAE_ENV", "standard"); err != nil {
+			log.Fatalf("couldn't set env GAE_ENV: %v", err)
+		}
 	}
 
 	return quit

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/influxdata/influxql v1.1.0
+	github.com/pkg/profile v1.2.1
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/timshannon/bolthold v0.0.0-20200817130212-4a25ab140645

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-bindata/go-bindata/v3 v3.1.3
-	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.2.1 h1:F++O52m40owAmADcojzM+9gyjmMOY/T4oYJkgFDH8RE=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
-github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -285,6 +285,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0 h1:reN85Pxc5larApoH1keMBiu2GWtPqXQ1nc9gx+jOU+E=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
+github.com/kisielk/errcheck v1.5.0 h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY=
+github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -694,6 +696,7 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -702,6 +705,7 @@ golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e h1:Z2uDrs8MyXUWJbwGc4V+nGjV4Ygo+oubBbWSVQw21/I=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 h1:K+NlvTLy0oONtRtkl1jRD9xIhnItbG2PiE7YOdjPb+k=
@@ -872,4 +876,5 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 h1:ucqkfpjg9WzSUubAO62csmucvxl4/JeW3F4I4909XkM=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/influxdb/metric_test.go
+++ b/influxdb/metric_test.go
@@ -38,7 +38,7 @@ import (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Save the emulator's quit channel.
-	quit := datastore.Emulator(ctx)
+	quit := datastore.Emulator(ctx, true)
 	code := m.Run()
 	cancel()
 	// Wait for channel close before exiting the test suite

--- a/stackdriver/adapter_test.go
+++ b/stackdriver/adapter_test.go
@@ -36,7 +36,7 @@ import (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Save the emulator's quit channel.
-	quit := datastore.Emulator(ctx)
+	quit := datastore.Emulator(ctx, true)
 	code := m.Run()
 	cancel()
 	// Wait for channel close before exiting the test suite

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -39,13 +39,7 @@ func LoadStorageEngine(ctx context.Context, config *tsbridge.Config) (storage.Ma
 }
 
 // Sync updates all configured metrics.
-func Sync(ctx context.Context, config *tsbridge.Config, metrics *tsbridge.Metrics) error {
-	store, err := LoadStorageEngine(ctx, config)
-	if err != nil {
-		return err
-	}
-	defer store.Close()
-
+func Sync(ctx context.Context, config *tsbridge.Config, metrics *tsbridge.Metrics, store storage.Manager) error {
 	metricCfg, err := tsbridge.NewMetricConfig(ctx, config, store)
 	if err != nil {
 		return err
@@ -58,13 +52,7 @@ func Sync(ctx context.Context, config *tsbridge.Config, metrics *tsbridge.Metric
 }
 
 // Cleanup removes obsolete metric records.
-func Cleanup(ctx context.Context, config *tsbridge.Config) error {
-	store, err := LoadStorageEngine(ctx, config)
-	if err != nil {
-		return err
-	}
-	defer store.Close()
-
+func Cleanup(ctx context.Context, config *tsbridge.Config, store storage.Manager) error {
 	metrics, err := tsbridge.NewMetricConfig(ctx, config, store)
 	if err != nil {
 		return err

--- a/tsbridge/common_test.go
+++ b/tsbridge/common_test.go
@@ -25,7 +25,7 @@ import (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Save the emulator's quit channel.
-	quit := datastore.Emulator(ctx)
+	quit := datastore.Emulator(ctx, true)
 	code := m.Run()
 	cancel()
 	// Wait for channel close before exiting the test suite

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -35,13 +35,13 @@ func TestHealthHandler(t *testing.T) {
 			})
 			store, err := tasks.LoadStorageEngine(context.Background(), config)
 			if err != nil {
-				t.Fatalf("Error while loading storage engine: %v", err)
+				t.Fatalf("error while loading storage engine: %v", err)
 			}
 			h := NewHandler(config, &tsbridge.Metrics{}, store)
 
 			req, err := http.NewRequest("GET", "/health", nil)
 			if err != nil {
-				t.Fatalf("Error while sending request for /health: %v", err)
+				t.Fatalf("error while sending request for /health: %v", err)
 			}
 
 			rr := httptest.NewRecorder()

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -18,7 +18,7 @@ func TestHealthHandler(t *testing.T) {
 		t.Run(storageEngineName, func(t *testing.T) {
 			config := tsbridge.NewConfig(&tsbridge.ConfigOptions{
 				StorageEngine:    storageEngineName,
-				DatastoreProject: "foo",
+				DatastoreProject: "testapp",
 			})
 			store, err := tasks.LoadStorageEngine(context.Background(), config)
 			if err != nil {
@@ -28,7 +28,7 @@ func TestHealthHandler(t *testing.T) {
 
 			req, err := http.NewRequest("GET", "/health", nil)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("Error while sending request for /health: %v", err)
 			}
 
 			rr := httptest.NewRecorder()

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -11,27 +11,40 @@ import (
 )
 
 func TestHealthHandler(t *testing.T) {
-	config := tsbridge.NewConfig(&tsbridge.ConfigOptions{})
-	store, err := tasks.LoadStorageEngine(context.Background(), config)
-	h := NewHandler(config, &tsbridge.Metrics{}, store)
+	for _, storageEngineName := range []string{
+		"boltdb",
+		"datastore",
+	} {
+		t.Run(storageEngineName, func(t *testing.T) {
+			config := tsbridge.NewConfig(&tsbridge.ConfigOptions{
+				StorageEngine:    storageEngineName,
+				DatastoreProject: "foo",
+			})
+			store, err := tasks.LoadStorageEngine(context.Background(), config)
+			if err != nil {
+				t.Fatalf("Error while loading storage engine: %v", err)
+			}
+			h := NewHandler(config, &tsbridge.Metrics{}, store)
 
-	req, err := http.NewRequest("GET", "/health", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+			req, err := http.NewRequest("GET", "/health", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	rr := httptest.NewRecorder()
-	adapter := http.HandlerFunc(h.Health)
-	adapter.ServeHTTP(rr, req)
+			rr := httptest.NewRecorder()
+			adapter := http.HandlerFunc(h.Health)
+			adapter.ServeHTTP(rr, req)
 
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusOK)
-	}
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v",
+					status, http.StatusOK)
+			}
 
-	expected := `{"status":"ok"}`
-	if rr.Body.String() != expected {
-		t.Errorf("handler returned unexpected body: got %v want %v",
-			rr.Body.String(), expected)
+			expected := `{"status":"ok"}`
+			if rr.Body.String() != expected {
+				t.Errorf("handler returned unexpected body: got %v want %v",
+					rr.Body.String(), expected)
+			}
+		})
 	}
 }

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -4,11 +4,24 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/google/ts-bridge/datastore"
 	"github.com/google/ts-bridge/tasks"
 	"github.com/google/ts-bridge/tsbridge"
 )
+
+func TestMain(m *testing.M) {
+	ctx, cancel := context.WithCancel(context.Background())
+	// Save the emulator's quit channel.
+	quit := datastore.Emulator(ctx, false)
+	code := m.Run()
+	cancel()
+	// Wait for channel close before exiting the test suite
+	<-quit
+	os.Exit(code)
+}
 
 func TestHealthHandler(t *testing.T) {
 	for _, storageEngineName := range []string{

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -1,16 +1,19 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/ts-bridge/tasks"
 	"github.com/google/ts-bridge/tsbridge"
 )
 
 func TestHealthHandler(t *testing.T) {
 	config := tsbridge.NewConfig(&tsbridge.ConfigOptions{})
-	h := NewHandler(config, &tsbridge.Metrics{})
+	store, err := tasks.LoadStorageEngine(context.Background(), config)
+	h := NewHandler(config, &tsbridge.Metrics{}, store)
 
 	req, err := http.NewRequest("GET", "/health", nil)
 	if err != nil {


### PR DESCRIPTION
This PR moves LoadStorageEngine outside of the Sync routine for a ~30% improvement in its runtime.

**Context:**
By running the pprof profiler, I've discovered that a third of the main sync routine's time is spent loading storage. (In the flame graph below, `Sync` uses 3.17% of root, where `LoadStorageEngine` accounts of 0.79%)
![image](https://user-images.githubusercontent.com/37109549/107179044-a0dd6780-6a29-11eb-9ff1-88a04f03eee0.png)

Since `LoadStorageEngine` was called inside `tasks.Sync`, the storage engine (boltDB/datastore) would be reloaded for every sync cycle. The storage engine for TS-Bridge can only be set via runtime flags. Therefore, it will not change during runtime, making this repeated loading of the storage engine unnecessary. 

To optimise this function, I refactored `LoadStorageEngine` to only be called once at the start of the program. After this refactor, the profiler output (see flame graph below) showed that the time spent on `tasks.Sync` had reduced from 3.17% to 2.16%, resulting in a ~30% improvement in efficiency.
![image](https://user-images.githubusercontent.com/37109549/107179381-7cce5600-6a2a-11eb-887c-d2ae4b4a4aaa.png)

**Caveat:**
There may be issues with parallelism but the only go routines we use are syncLoop and writing to StackDriver, so the storage engine should still be unaffected.
