### PR TITLE
Refactored metric config to conditionally update metric config

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -160,7 +160,12 @@ func main() {
 	}
 	defer store.Close()
 
-	h := web.NewHandler(config, metrics, store)
+	metricCfg, err := tsbridge.NewMetricConfig(context.Background(), config, store)
+	if err != nil {
+		log.Fatalf("failed to perform initial load of metric config: %v", err)
+	}
+
+	h := web.NewHandler(config, metrics, metricCfg, store)
 	http.HandleFunc("/", h.Index)
 	http.HandleFunc("/sync", h.Sync)
 	http.HandleFunc("/cleanup", h.Cleanup)
@@ -177,7 +182,7 @@ func main() {
 	if !env.IsAppEngine() {
 		log.Debug("Running outside of appengine, starting up a sync loop...")
 		ctx, cancel := context.WithCancel(context.Background())
-		go syncLoop(ctx, cancel, config, metrics, store)
+		go syncLoop(ctx, cancel, config, metrics, metricCfg, store)
 	}
 
 	// Build a connection string, e.g. ":8080"
@@ -189,16 +194,20 @@ func main() {
 
 }
 
-func syncLoop(ctx context.Context, cancel context.CancelFunc, config *tsbridge.Config, metrics *tsbridge.Metrics, store storage.Manager) {
+func syncLoop(ctx context.Context, cancel context.CancelFunc, config *tsbridge.Config, metrics *tsbridge.Metrics, metricCfg *tsbridge.MetricConfig, store storage.Manager) {
 	defer cancel()
+
 	for {
 		select {
 		case <-time.After(config.Options.SyncPeriod):
 			log.Debugf("Goroutines: %v", runtime.NumGoroutine())
 			ctx, cancel := context.WithTimeout(ctx, config.Options.UpdateTimeout)
 			log.WithContext(ctx).Debugf("Running sync...")
-			if err := tasks.Sync(ctx, config, metrics, store); err != nil {
-				log.WithContext(ctx).Errorf("error running sync() routine: %v", err)
+			if err := tasks.SyncMetricConfig(ctx, config, store, metricCfg); err != nil {
+				log.WithContext(ctx).Errorf("error running SyncMetricConfig() within sync() routine: %v", err)
+			}
+			if err := tasks.SyncMetrics(ctx, config, metrics, metricCfg); err != nil {
+				log.WithContext(ctx).Errorf("error running SyncMetrics() routine: %v", err)
 			}
 			cancel()
 		case <-ctx.Done():

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
+	github.com/google/martian v2.1.0+incompatible
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/influxdata/influxql v1.1.0
 	github.com/pkg/profile v1.5.0

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -46,7 +46,7 @@ func isMetricCfgUpdated(ctx context.Context, filename string, metricCfgFs *os.Fi
 	if err != nil {
 		return false, err
 	}
-	return (*metricCfgFs).ModTime() != fs.ModTime() && (*metricCfgFs).Size() != fs.Size(), nil
+	return (*metricCfgFs).ModTime() != fs.ModTime(), nil
 }
 
 // SyncMetricConfig ensures that metric config is always synced with the metric config file. This should only be called when !env.IsAppEngine().

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -18,17 +18,18 @@ import (
 )
 
 type Handler struct {
-	config  *tsbridge.Config
-	Metrics *tsbridge.Metrics
-	store   storage.Manager
+	config    *tsbridge.Config
+	Metrics   *tsbridge.Metrics
+	metricCfg *tsbridge.MetricConfig
+	store     storage.Manager
 }
 
 type HealthResponse struct {
 	Status string `json:"status,omitempty"`
 }
 
-func NewHandler(config *tsbridge.Config, metrics *tsbridge.Metrics, store storage.Manager) *Handler {
-	return &Handler{config: config, Metrics: metrics, store: store}
+func NewHandler(config *tsbridge.Config, metrics *tsbridge.Metrics, metricCfg *tsbridge.MetricConfig, store storage.Manager) *Handler {
+	return &Handler{config: config, Metrics: metrics, store: store, metricCfg: metricCfg}
 }
 
 // Sync is an HTTP wrapper around sync() method that is designed to be triggered by App Engine Cron.
@@ -43,7 +44,7 @@ func (h *Handler) Sync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := tasks.Sync(ctx, h.config, h.Metrics, h.store); err != nil {
+	if err := tasks.SyncMetrics(ctx, h.config, h.Metrics, h.metricCfg); err != nil {
 		logAndReturnError(ctx, w, err)
 	}
 }

--- a/web/testdata/valid.yaml
+++ b/web/testdata/valid.yaml
@@ -1,0 +1,16 @@
+datadog_metrics:
+  - name: metric1
+    query: "query one"
+    api_key: xxx
+    application_key: xxx
+    destination: stackdriver
+influxdb_metrics:
+  - name: metric2
+    query: "query two"
+    database: db
+    endpoint: localhost:8888
+    destination: stackdriver
+stackdriver_destinations:
+  - name: stackdriver
+  - name: another_stackdriver
+    project_id: "another-projectname"


### PR DESCRIPTION
This PR splits tasks.Sync to avoid unnecessary reloads of the `metrics.yaml` file.

**Context**:
TSB users may potentially update their `metrics.yaml` file during runtime, and such changes must be propagated to the imported metrics quickly. Previously, this was achieved by reloading the metric config from `metrics.yaml` every sync loop via `NewMetricConfig(...)`. 

As shown in pprof profiler flame graphs, NewMetricConfig accounts for a large part of the update routine. 
![image](https://user-images.githubusercontent.com/37109549/107604305-d8dfe700-6c83-11eb-83d9-5b53b8c0fb47.png)

**Changes:**
This PR refactors the code to only reload metric configs when the file has been modified. This was done by maintaining a cache of the `metrics.yaml`'s FileInfo (obtained using os.Stats(), which works for symlinks) within the `MetricConfig` struct. A file is assumed to be modified if both its `.Size()` and `.ModTime()` is different from those previously cached in the binary. 

**Result:**
the `syncLoop()` function now takes 0.63% of the total profile compared to the previous ~3%.
![image](https://user-images.githubusercontent.com/37109549/107604662-e8abfb00-6c84-11eb-9f6e-05ba80c3f321.png)