### PR TITLE
Update go generated files for go ver 1.1[3-5]x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/influxdata/influxql v1.1.0
+	github.com/kisielk/errcheck v1.6.0 // indirect
 	github.com/pkg/profile v1.5.0
 	github.com/prometheus/client_golang v1.8.0 // indirect
 	github.com/sirupsen/logrus v1.8.0
@@ -23,6 +24,8 @@ require (
 	github.com/zorkian/go-datadog-api v2.30.0+incompatible
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.opencensus.io v0.23.0
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750 // indirect
 	google.golang.org/api v0.40.0
 	google.golang.org/genproto v0.0.0-20210202153253-cf70463f6119
 	google.golang.org/grpc v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/kisielk/errcheck v1.2.0 h1:reN85Pxc5larApoH1keMBiu2GWtPqXQ1nc9gx+jOU+
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0 h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+github.com/kisielk/errcheck v1.6.0 h1:YTDO4pNy7AUN/021p+JGHycQyYNIyMoenM1YDVK6RlY=
+github.com/kisielk/errcheck v1.6.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -508,6 +510,8 @@ golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -640,6 +644,8 @@ golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750 h1:ZBu6861dZq7xBnG1bn5SRU0vA8nx42at4+kP07FMTog=
+golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/mocks/mock_metric_record.go
+++ b/mocks/mock_metric_record.go
@@ -6,35 +6,36 @@ package mocks
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockMetricRecord is a mock of MetricRecord interface
+// MockMetricRecord is a mock of MetricRecord interface.
 type MockMetricRecord struct {
 	ctrl     *gomock.Controller
 	recorder *MockMetricRecordMockRecorder
 }
 
-// MockMetricRecordMockRecorder is the mock recorder for MockMetricRecord
+// MockMetricRecordMockRecorder is the mock recorder for MockMetricRecord.
 type MockMetricRecordMockRecorder struct {
 	mock *MockMetricRecord
 }
 
-// NewMockMetricRecord creates a new mock instance
+// NewMockMetricRecord creates a new mock instance.
 func NewMockMetricRecord(ctrl *gomock.Controller) *MockMetricRecord {
 	mock := &MockMetricRecord{ctrl: ctrl}
 	mock.recorder = &MockMetricRecordMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMetricRecord) EXPECT() *MockMetricRecordMockRecorder {
 	return m.recorder
 }
 
-// GetCounterStartTime mocks base method
+// GetCounterStartTime mocks base method.
 func (m *MockMetricRecord) GetCounterStartTime() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCounterStartTime")
@@ -42,13 +43,13 @@ func (m *MockMetricRecord) GetCounterStartTime() time.Time {
 	return ret0
 }
 
-// GetCounterStartTime indicates an expected call of GetCounterStartTime
+// GetCounterStartTime indicates an expected call of GetCounterStartTime.
 func (mr *MockMetricRecordMockRecorder) GetCounterStartTime() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCounterStartTime", reflect.TypeOf((*MockMetricRecord)(nil).GetCounterStartTime))
 }
 
-// GetLastUpdate mocks base method
+// GetLastUpdate mocks base method.
 func (m *MockMetricRecord) GetLastUpdate() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLastUpdate")
@@ -56,13 +57,13 @@ func (m *MockMetricRecord) GetLastUpdate() time.Time {
 	return ret0
 }
 
-// GetLastUpdate indicates an expected call of GetLastUpdate
+// GetLastUpdate indicates an expected call of GetLastUpdate.
 func (mr *MockMetricRecordMockRecorder) GetLastUpdate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastUpdate", reflect.TypeOf((*MockMetricRecord)(nil).GetLastUpdate))
 }
 
-// SetCounterStartTime mocks base method
+// SetCounterStartTime mocks base method.
 func (m *MockMetricRecord) SetCounterStartTime(arg0 context.Context, arg1 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCounterStartTime", arg0, arg1)
@@ -70,13 +71,13 @@ func (m *MockMetricRecord) SetCounterStartTime(arg0 context.Context, arg1 time.T
 	return ret0
 }
 
-// SetCounterStartTime indicates an expected call of SetCounterStartTime
+// SetCounterStartTime indicates an expected call of SetCounterStartTime.
 func (mr *MockMetricRecordMockRecorder) SetCounterStartTime(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCounterStartTime", reflect.TypeOf((*MockMetricRecord)(nil).SetCounterStartTime), arg0, arg1)
 }
 
-// UpdateError mocks base method
+// UpdateError mocks base method.
 func (m *MockMetricRecord) UpdateError(arg0 context.Context, arg1 error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateError", arg0, arg1)
@@ -84,13 +85,13 @@ func (m *MockMetricRecord) UpdateError(arg0 context.Context, arg1 error) error {
 	return ret0
 }
 
-// UpdateError indicates an expected call of UpdateError
+// UpdateError indicates an expected call of UpdateError.
 func (mr *MockMetricRecordMockRecorder) UpdateError(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateError", reflect.TypeOf((*MockMetricRecord)(nil).UpdateError), arg0, arg1)
 }
 
-// UpdateSuccess mocks base method
+// UpdateSuccess mocks base method.
 func (m *MockMetricRecord) UpdateSuccess(arg0 context.Context, arg1 int, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSuccess", arg0, arg1, arg2)
@@ -98,7 +99,7 @@ func (m *MockMetricRecord) UpdateSuccess(arg0 context.Context, arg1 int, arg2 st
 	return ret0
 }
 
-// UpdateSuccess indicates an expected call of UpdateSuccess
+// UpdateSuccess indicates an expected call of UpdateSuccess.
 func (mr *MockMetricRecordMockRecorder) UpdateSuccess(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSuccess", reflect.TypeOf((*MockMetricRecord)(nil).UpdateSuccess), arg0, arg1, arg2)

--- a/mocks/mock_sd_adapter.go
+++ b/mocks/mock_sd_adapter.go
@@ -6,37 +6,38 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	metric "google.golang.org/genproto/googleapis/api/metric"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
-	reflect "reflect"
-	time "time"
 )
 
-// MockStackdriverAdapter is a mock of StackdriverAdapter interface
+// MockStackdriverAdapter is a mock of StackdriverAdapter interface.
 type MockStackdriverAdapter struct {
 	ctrl     *gomock.Controller
 	recorder *MockStackdriverAdapterMockRecorder
 }
 
-// MockStackdriverAdapterMockRecorder is the mock recorder for MockStackdriverAdapter
+// MockStackdriverAdapterMockRecorder is the mock recorder for MockStackdriverAdapter.
 type MockStackdriverAdapterMockRecorder struct {
 	mock *MockStackdriverAdapter
 }
 
-// NewMockStackdriverAdapter creates a new mock instance
+// NewMockStackdriverAdapter creates a new mock instance.
 func NewMockStackdriverAdapter(ctrl *gomock.Controller) *MockStackdriverAdapter {
 	mock := &MockStackdriverAdapter{ctrl: ctrl}
 	mock.recorder = &MockStackdriverAdapterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStackdriverAdapter) EXPECT() *MockStackdriverAdapterMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockStackdriverAdapter) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -44,13 +45,13 @@ func (m *MockStackdriverAdapter) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockStackdriverAdapterMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStackdriverAdapter)(nil).Close))
 }
 
-// CreateTimeseries mocks base method
+// CreateTimeseries mocks base method.
 func (m *MockStackdriverAdapter) CreateTimeseries(arg0 context.Context, arg1, arg2 string, arg3 *metric.MetricDescriptor, arg4 []*monitoring.TimeSeries) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTimeseries", arg0, arg1, arg2, arg3, arg4)
@@ -58,13 +59,13 @@ func (m *MockStackdriverAdapter) CreateTimeseries(arg0 context.Context, arg1, ar
 	return ret0
 }
 
-// CreateTimeseries indicates an expected call of CreateTimeseries
+// CreateTimeseries indicates an expected call of CreateTimeseries.
 func (mr *MockStackdriverAdapterMockRecorder) CreateTimeseries(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTimeseries", reflect.TypeOf((*MockStackdriverAdapter)(nil).CreateTimeseries), arg0, arg1, arg2, arg3, arg4)
 }
 
-// LatestTimestamp mocks base method
+// LatestTimestamp mocks base method.
 func (m *MockStackdriverAdapter) LatestTimestamp(arg0 context.Context, arg1, arg2 string) (time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LatestTimestamp", arg0, arg1, arg2)
@@ -73,7 +74,7 @@ func (m *MockStackdriverAdapter) LatestTimestamp(arg0 context.Context, arg1, arg
 	return ret0, ret1
 }
 
-// LatestTimestamp indicates an expected call of LatestTimestamp
+// LatestTimestamp indicates an expected call of LatestTimestamp.
 func (mr *MockStackdriverAdapterMockRecorder) LatestTimestamp(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestTimestamp", reflect.TypeOf((*MockStackdriverAdapter)(nil).LatestTimestamp), arg0, arg1, arg2)

--- a/mocks/mock_sd_metric_client.go
+++ b/mocks/mock_sd_metric_client.go
@@ -6,36 +6,37 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	metric "google.golang.org/genproto/googleapis/api/metric"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
-	reflect "reflect"
 )
 
-// MockMetricClient is a mock of MetricClient interface
+// MockMetricClient is a mock of MetricClient interface.
 type MockMetricClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockMetricClientMockRecorder
 }
 
-// MockMetricClientMockRecorder is the mock recorder for MockMetricClient
+// MockMetricClientMockRecorder is the mock recorder for MockMetricClient.
 type MockMetricClientMockRecorder struct {
 	mock *MockMetricClient
 }
 
-// NewMockMetricClient creates a new mock instance
+// NewMockMetricClient creates a new mock instance.
 func NewMockMetricClient(ctrl *gomock.Controller) *MockMetricClient {
 	mock := &MockMetricClient{ctrl: ctrl}
 	mock.recorder = &MockMetricClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMetricClient) EXPECT() *MockMetricClientMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockMetricClient) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -43,13 +44,13 @@ func (m *MockMetricClient) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockMetricClientMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockMetricClient)(nil).Close))
 }
 
-// CreateMetricDescriptor mocks base method
+// CreateMetricDescriptor mocks base method.
 func (m *MockMetricClient) CreateMetricDescriptor(arg0 context.Context, arg1 *monitoring.CreateMetricDescriptorRequest) (*metric.MetricDescriptor, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMetricDescriptor", arg0, arg1)
@@ -58,13 +59,13 @@ func (m *MockMetricClient) CreateMetricDescriptor(arg0 context.Context, arg1 *mo
 	return ret0, ret1
 }
 
-// CreateMetricDescriptor indicates an expected call of CreateMetricDescriptor
+// CreateMetricDescriptor indicates an expected call of CreateMetricDescriptor.
 func (mr *MockMetricClientMockRecorder) CreateMetricDescriptor(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMetricDescriptor", reflect.TypeOf((*MockMetricClient)(nil).CreateMetricDescriptor), arg0, arg1)
 }
 
-// CreateTimeSeries mocks base method
+// CreateTimeSeries mocks base method.
 func (m *MockMetricClient) CreateTimeSeries(arg0 context.Context, arg1 *monitoring.CreateTimeSeriesRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTimeSeries", arg0, arg1)
@@ -72,13 +73,13 @@ func (m *MockMetricClient) CreateTimeSeries(arg0 context.Context, arg1 *monitori
 	return ret0
 }
 
-// CreateTimeSeries indicates an expected call of CreateTimeSeries
+// CreateTimeSeries indicates an expected call of CreateTimeSeries.
 func (mr *MockMetricClientMockRecorder) CreateTimeSeries(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTimeSeries", reflect.TypeOf((*MockMetricClient)(nil).CreateTimeSeries), arg0, arg1)
 }
 
-// DeleteMetricDescriptor mocks base method
+// DeleteMetricDescriptor mocks base method.
 func (m *MockMetricClient) DeleteMetricDescriptor(arg0 context.Context, arg1 *monitoring.DeleteMetricDescriptorRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMetricDescriptor", arg0, arg1)
@@ -86,13 +87,13 @@ func (m *MockMetricClient) DeleteMetricDescriptor(arg0 context.Context, arg1 *mo
 	return ret0
 }
 
-// DeleteMetricDescriptor indicates an expected call of DeleteMetricDescriptor
+// DeleteMetricDescriptor indicates an expected call of DeleteMetricDescriptor.
 func (mr *MockMetricClientMockRecorder) DeleteMetricDescriptor(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMetricDescriptor", reflect.TypeOf((*MockMetricClient)(nil).DeleteMetricDescriptor), arg0, arg1)
 }
 
-// GetMetricDescriptor mocks base method
+// GetMetricDescriptor mocks base method.
 func (m *MockMetricClient) GetMetricDescriptor(arg0 context.Context, arg1 *monitoring.GetMetricDescriptorRequest) (*metric.MetricDescriptor, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricDescriptor", arg0, arg1)
@@ -101,13 +102,13 @@ func (m *MockMetricClient) GetMetricDescriptor(arg0 context.Context, arg1 *monit
 	return ret0, ret1
 }
 
-// GetMetricDescriptor indicates an expected call of GetMetricDescriptor
+// GetMetricDescriptor indicates an expected call of GetMetricDescriptor.
 func (mr *MockMetricClientMockRecorder) GetMetricDescriptor(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricDescriptor", reflect.TypeOf((*MockMetricClient)(nil).GetMetricDescriptor), arg0, arg1)
 }
 
-// ListTimeSeries mocks base method
+// ListTimeSeries mocks base method.
 func (m *MockMetricClient) ListTimeSeries(arg0 context.Context, arg1 *monitoring.ListTimeSeriesRequest) ([]*monitoring.TimeSeries, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTimeSeries", arg0, arg1)
@@ -116,7 +117,7 @@ func (m *MockMetricClient) ListTimeSeries(arg0 context.Context, arg1 *monitoring
 	return ret0, ret1
 }
 
-// ListTimeSeries indicates an expected call of ListTimeSeries
+// ListTimeSeries indicates an expected call of ListTimeSeries.
 func (mr *MockMetricClientMockRecorder) ListTimeSeries(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTimeSeries", reflect.TypeOf((*MockMetricClient)(nil).ListTimeSeries), arg0, arg1)

--- a/mocks/mock_source_metric.go
+++ b/mocks/mock_source_metric.go
@@ -6,38 +6,39 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	storage "github.com/google/ts-bridge/storage"
 	metric "google.golang.org/genproto/googleapis/api/metric"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
-	reflect "reflect"
-	time "time"
 )
 
-// MockSourceMetric is a mock of SourceMetric interface
+// MockSourceMetric is a mock of SourceMetric interface.
 type MockSourceMetric struct {
 	ctrl     *gomock.Controller
 	recorder *MockSourceMetricMockRecorder
 }
 
-// MockSourceMetricMockRecorder is the mock recorder for MockSourceMetric
+// MockSourceMetricMockRecorder is the mock recorder for MockSourceMetric.
 type MockSourceMetricMockRecorder struct {
 	mock *MockSourceMetric
 }
 
-// NewMockSourceMetric creates a new mock instance
+// NewMockSourceMetric creates a new mock instance.
 func NewMockSourceMetric(ctrl *gomock.Controller) *MockSourceMetric {
 	mock := &MockSourceMetric{ctrl: ctrl}
 	mock.recorder = &MockSourceMetricMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSourceMetric) EXPECT() *MockSourceMetricMockRecorder {
 	return m.recorder
 }
 
-// Query mocks base method
+// Query mocks base method.
 func (m *MockSourceMetric) Query() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Query")
@@ -45,13 +46,13 @@ func (m *MockSourceMetric) Query() string {
 	return ret0
 }
 
-// Query indicates an expected call of Query
+// Query indicates an expected call of Query.
 func (mr *MockSourceMetricMockRecorder) Query() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Query", reflect.TypeOf((*MockSourceMetric)(nil).Query))
 }
 
-// StackdriverData mocks base method
+// StackdriverData mocks base method.
 func (m *MockSourceMetric) StackdriverData(arg0 context.Context, arg1 time.Time, arg2 storage.MetricRecord) (*metric.MetricDescriptor, []*monitoring.TimeSeries, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StackdriverData", arg0, arg1, arg2)
@@ -61,13 +62,13 @@ func (m *MockSourceMetric) StackdriverData(arg0 context.Context, arg1 time.Time,
 	return ret0, ret1, ret2
 }
 
-// StackdriverData indicates an expected call of StackdriverData
+// StackdriverData indicates an expected call of StackdriverData.
 func (mr *MockSourceMetricMockRecorder) StackdriverData(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackdriverData", reflect.TypeOf((*MockSourceMetric)(nil).StackdriverData), arg0, arg1, arg2)
 }
 
-// StackdriverName mocks base method
+// StackdriverName mocks base method.
 func (m *MockSourceMetric) StackdriverName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StackdriverName")
@@ -75,7 +76,7 @@ func (m *MockSourceMetric) StackdriverName() string {
 	return ret0
 }
 
-// StackdriverName indicates an expected call of StackdriverName
+// StackdriverName indicates an expected call of StackdriverName.
 func (mr *MockSourceMetricMockRecorder) StackdriverName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackdriverName", reflect.TypeOf((*MockSourceMetric)(nil).StackdriverName))

--- a/mocks/mock_storage_manager.go
+++ b/mocks/mock_storage_manager.go
@@ -6,35 +6,36 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	storage "github.com/google/ts-bridge/storage"
-	reflect "reflect"
 )
 
-// MockManager is a mock of Manager interface
+// MockManager is a mock of Manager interface.
 type MockManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerMockRecorder
 }
 
-// MockManagerMockRecorder is the mock recorder for MockManager
+// MockManagerMockRecorder is the mock recorder for MockManager.
 type MockManagerMockRecorder struct {
 	mock *MockManager
 }
 
-// NewMockManager creates a new mock instance
+// NewMockManager creates a new mock instance.
 func NewMockManager(ctrl *gomock.Controller) *MockManager {
 	mock := &MockManager{ctrl: ctrl}
 	mock.recorder = &MockManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
-// CleanupRecords mocks base method
+// CleanupRecords mocks base method.
 func (m *MockManager) CleanupRecords(arg0 context.Context, arg1 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupRecords", arg0, arg1)
@@ -42,13 +43,13 @@ func (m *MockManager) CleanupRecords(arg0 context.Context, arg1 []string) error 
 	return ret0
 }
 
-// CleanupRecords indicates an expected call of CleanupRecords
+// CleanupRecords indicates an expected call of CleanupRecords.
 func (mr *MockManagerMockRecorder) CleanupRecords(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupRecords", reflect.TypeOf((*MockManager)(nil).CleanupRecords), arg0, arg1)
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockManager) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -56,13 +57,13 @@ func (m *MockManager) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockManagerMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockManager)(nil).Close))
 }
 
-// NewMetricRecord mocks base method
+// NewMetricRecord mocks base method.
 func (m *MockManager) NewMetricRecord(arg0 context.Context, arg1, arg2 string) (storage.MetricRecord, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewMetricRecord", arg0, arg1, arg2)
@@ -71,7 +72,7 @@ func (m *MockManager) NewMetricRecord(arg0 context.Context, arg1, arg2 string) (
 	return ret0, ret1
 }
 
-// NewMetricRecord indicates an expected call of NewMetricRecord
+// NewMetricRecord indicates an expected call of NewMetricRecord.
 func (mr *MockManagerMockRecorder) NewMetricRecord(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMetricRecord", reflect.TypeOf((*MockManager)(nil).NewMetricRecord), arg0, arg1, arg2)


### PR DESCRIPTION
go generate now adds a "." at the end of comment strings. updating the generated files to prevent test failures

eg. https://github.com/google/ts-bridge/runs/2063426061

go.mod will produce a diff for go 1.16x as our module dependencies are pinned to ver 1.13. This will be fixed in https://github.com/google/ts-bridge/issues/110