### PR TITLE
update prometheus to min v2.7.1 due to CVE-2019-3826

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,3 +34,5 @@ require (
 replace golang.org/x/text v0.3.6 => golang.org/x/text v0.3.8 // CVE-2021-38561
 
 replace golang.org/x/text v0.3.7 => golang.org/x/text v0.3.8 // CVE-2022-32149
+
+replace github.com/prometheus/prometheus v0.35.0 => github.com/prometheus/prometheus/v2 v2.7.1 // CVE-2019-3826


### PR DESCRIPTION
```
┌──────────────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│             Library              │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                            Title                             │
├──────────────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/prometheus/prometheus │ CVE-2019-3826 │ MEDIUM   │ v0.35.0           │ v2.7.1        │ prometheus: Stored DOM cross-site scripting (XSS) attack via │
│                                  │               │          │                   │               │ crafted URL                                                  │
│                                  │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-3826                    │
└──────────────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```