### PR TITLE
Update gcloud used in Go CI tests

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up gcloud datastore emulator
         # JRE is needed for the datastore emulator
         run: |
-          curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-307.0.0-linux-x86_64.tar.gz | tar xfz - -C $HOME
+          curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-427.0.0-linux-x86_64.tar.gz | tar xfz - -C $HOME
           $HOME/google-cloud-sdk/bin/gcloud components install beta cloud-datastore-emulator
           sudo apt-get update
           sudo apt-get install openjdk-8-jre-headless


### PR DESCRIPTION
gcloud 307 fails with `gcloud failed to load: module 'collections' has no attribute 'MutableMapping'`, which is an incompatibility with Python 3.10.6 currently shipping with the [ubuntu-latest image](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md).
