### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set Go version
         id: go
-        run: echo "::set-output name=go-version::$(cat .go-version)"
+        run: echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
 
   install-and-run:
     name: Tests Go ${{ matrix.go-version }} ${{ matrix.name }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter